### PR TITLE
New SPOfficeOnlineServerBinding resource

### DIFF
--- a/.vscode/ScriptAnalyzerSettings.psd1
+++ b/.vscode/ScriptAnalyzerSettings.psd1
@@ -1,4 +1,4 @@
 @{
     Severity=@('Error','Warning')
-    ExcludeRules=@('PSMissingModuleManifestField')
+    ExcludeRules=@('PSMissingModuleManifestField','PSUseShouldProcessForStateChangingFunctions')
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
  * Fixed a bug with SPTimerJobState that prevented a custom schedule being applied to a timer job
+ * Added SPOfficeOnlineServerBinding resource
 
 ### 1.0
 

--- a/Modules/SharePointDSC/Examples/Single Server/SharePoint.ps1
+++ b/Modules/SharePointDSC/Examples/Single Server/SharePoint.ps1
@@ -294,6 +294,15 @@ Configuration SharePointServer
             PsDscRunAsCredential = $SPSetupAccount
             DependsOn            = "[SPCreateFarm]CreateSPFarm"
         }
+
+        SPOfficeOnlineServerBinding OosBinding
+        {
+            Zone                 = "internal-https"
+            DnsName              = "office.contoso.com"
+            Ensure               = "Present"
+            PsDscRunAsCredential = $SPSetupAccount
+            DependsOn            = "[SPCreateFarm]CreateSPFarm"
+        }
         
         #**********************************************************
         # Service applications

--- a/Modules/SharePointDSC/Examples/Small Farm/SharePoint.ps1
+++ b/Modules/SharePointDSC/Examples/Small Farm/SharePoint.ps1
@@ -183,6 +183,15 @@ Configuration SharePointServer
                 PsDscRunAsCredential = $SPSetupAccount
                 DependsOn            = $FarmWaitTask
             }
+
+            SPOfficeOnlineServerBinding OosBinding
+            {
+                Zone                 = "internal-https"
+                DnsName              = "office.contoso.com"
+                Ensure               = "Present"
+                PsDscRunAsCredential = $SPSetupAccount
+                DependsOn            = $FarmWaitTask
+            }
         }
         
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
@@ -52,8 +52,8 @@ function Set-TargetResource
     $CurrentResults = Get-TargetResource @PSBoundParameters
 
     if ($Ensure -eq "Present") { 
-        if ($DnsName -ne $CurrentResults.DnsName) {
-            if ([String]::IsNullOrEmpty($CurrentResults.DnsName) -eq $false) {
+        if ($DnsName -ne $CurrentResults.DnsName -or $Zone -ne $CurrentResults.Zone) {
+            if ([String]::IsNullOrEmpty($CurrentResults.DnsName) -eq $false -or $Zone -ne $CurrentResults.Zone) {
                 Write-Verbose -Message "Removing bindings for zone '$Zone' so new bindings can be added"
                 Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
                     $params = $args[0]

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
@@ -52,7 +52,7 @@ function Set-TargetResource
     $CurrentResults = Get-TargetResource @PSBoundParameters
 
     if ($Ensure -eq "Present") { 
-        if ($DnsName -ne $CurrentResults.DnsNzme) {
+        if ($DnsName -ne $CurrentResults.DnsName) {
             if ([String]::IsNullOrEmpty($CurrentResults.DnsName) -eq $false) {
                 Write-Verbose -Message "Removing bindings for zone '$Zone' so new bindings can be added"
                 Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.psm1
@@ -1,0 +1,113 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]  [ValidateSet("Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS")] [System.String]  $Zone,
+        [parameter(Mandatory = $true)]  [System.String]  $DnsName,
+        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
+        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+    )
+
+    Write-Verbose -Message "Looking up the Office Online Server details for '$Zone' zone"
+
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+        $params = $args[0]        
+        
+        $currentZone = Get-SPWOPIZone
+        $bindings = Get-SPWOPIBinding -WOPIZone $currentZone
+
+        if ($null -eq $bindings) {
+            return @{
+                Zone           = $currentZone
+                DnsName        = $null
+                Ensure         = "Absent"
+                InstallAccount = $params.InstallAccount
+            }
+        } else {
+            return @{
+                Zone           = $currentZone
+                DnsName        = ($bindings | Select-Object -First 1).ServerName
+                Ensure         = "Present"
+                InstallAccount = $params.InstallAccount
+            }
+        }
+    }
+    return $result
+}
+
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]  [ValidateSet("Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS")] [System.String]  $Zone,
+        [parameter(Mandatory = $true)]  [System.String]  $DnsName,
+        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
+        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+    )
+
+    $CurrentResults = Get-TargetResource @PSBoundParameters
+
+    if ($Ensure -eq "Present") { 
+        if ($DnsName -ne $CurrentResults.DnsNzme) {
+            if ([String]::IsNullOrEmpty($CurrentResults.DnsName) -eq $false) {
+                Write-Verbose -Message "Removing bindings for zone '$Zone' so new bindings can be added"
+                Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+                    $params = $args[0]
+                    Get-SPWOPIBinding -WOPIZone $params.Zone | Remove-SPWOPIBinding -Confirm:$false
+                }   
+            }
+            Write-Verbose "Creating new bindings for '$DnsName' and setting zone to '$Zone'"    
+            Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+                $params = $args[0]
+
+                $newParams = @{
+                    ServerName = $params.DnsName
+                }
+                if ($params.Zone.ToLower().EndsWith("http") -eq $true) {
+                    $newParams.Add("AllowHTTP", $true)
+                }
+                New-SPWOPIBinding @newParams
+                Set-SPWOPIZone -zone $params.Zone
+            }
+        }
+    }
+    
+    if ($Ensure -eq "Absent") {
+        Write-Verbose -Message "Removing bindings for zone '$Zone'"
+        Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+            $params = $args[0]
+            Get-SPWOPIBinding -WOPIZone $params.Zone | Remove-SPWOPIBinding -Confirm:$false
+        }
+    }
+}
+
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]  [ValidateSet("Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS")] [System.String]  $Zone,
+        [parameter(Mandatory = $true)]  [System.String]  $DnsName,
+        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
+        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+    )
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $PSBoundParameters.Ensure = $Ensure
+
+    Write-Verbose -Message "Testing Office Online Server details for '$Zone' zone"
+    
+    if ($Ensure -eq "Present") {
+        return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Zone","DnsName", "Ensure")
+    } else {
+        return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Ensure")   
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.schema.mof
@@ -1,0 +1,28 @@
+/*
+**Description**
+
+This resource will create a binding to an Office Online Server (formerly known as Office Web Apps). 
+The DnsName property can be a single server name, or a FQDN of a load balanced end point that will direct traffic to a farm.
+
+NOTE: This resource is designed to be used where all WOPI bindings will be targeted to the same Office Online Server farm.
+If used on a clean environment, the new bindings will all point to the one DNS Name.
+If used on an existing configuration that does not follow this rule, it will match only the first DNS name it finds in the list of bindings.
+
+**Example**
+
+    SPOfficeOnlineServerBinding OosBinding 
+    {
+        Zone                 = "internal-https"
+        DnsName              = "webapps.contoso.com"
+        Ensure               = "Present"
+        PsDscRunAsCredential = $SetupAccount
+    }
+*/
+[ClassVersion("1.0.0.0"), FriendlyName("SPOfficeOnlineServerBinding")]
+class MSFT_SPOfficeOnlineServerBinding : OMI_BaseResource
+{
+    [Key, Description("The zone for this binding"), ValueMap{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}, Values{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}] boolean Zone;
+    [Required, Description("The DNS name of the server/s that are running Office Web Apps")] string DnsName;
+    [Write, Description("Present ensures the binding for this zone exists, absent ensures it doesn't"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+};

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOfficeOnlineServerBinding/MSFT_SPOfficeOnlineServerBinding.schema.mof
@@ -21,7 +21,7 @@ If used on an existing configuration that does not follow this rule, it will mat
 [ClassVersion("1.0.0.0"), FriendlyName("SPOfficeOnlineServerBinding")]
 class MSFT_SPOfficeOnlineServerBinding : OMI_BaseResource
 {
-    [Key, Description("The zone for this binding"), ValueMap{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}, Values{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}] boolean Zone;
+    [Key, Description("The zone for this binding"), ValueMap{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}, Values{"Internal-HTTP","Internal-HTTPS","External-HTTP","External-HTTPS"}] string Zone;
     [Required, Description("The DNS name of the server/s that are running Office Web Apps")] string DnsName;
     [Write, Description("Present ensures the binding for this zone exists, absent ensures it doesn't"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;

--- a/Tests/SharePointDsc/SharePointDsc.SPOfficeOnlineServerBinding.Tests.ps1
+++ b/Tests/SharePointDsc/SharePointDsc.SPOfficeOnlineServerBinding.Tests.ps1
@@ -1,0 +1,161 @@
+[CmdletBinding()]
+param(
+    [string] $SharePointCmdletModule = (Join-Path $PSScriptRoot "..\Stubs\SharePoint\15.0.4805.1000\Microsoft.SharePoint.PowerShell.psm1" -Resolve)
+)
+
+$ErrorActionPreference = 'stop'
+Set-StrictMode -Version latest
+
+$RepoRoot = (Resolve-Path $PSScriptRoot\..\..).Path
+$Global:CurrentSharePointStubModule = $SharePointCmdletModule
+
+$ModuleName = "MSFT_SPOfficeOnlineServerBinding"
+Import-Module (Join-Path $RepoRoot "Modules\SharePointDSC\DSCResources\$ModuleName\$ModuleName.psm1") -Force
+
+Describe "SPOfficeOnlineServerBinding - SharePoint Build $((Get-Item $SharePointCmdletModule).Directory.BaseName)" {
+    InModuleScope $ModuleName {
+        Import-Module (Join-Path ((Resolve-Path $PSScriptRoot\..\..).Path) "Modules\SharePointDSC")
+        
+        Mock Invoke-SPDSCCommand { 
+            return Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $Arguments -NoNewScope
+        }
+        
+        Remove-Module -Name "Microsoft.SharePoint.PowerShell" -Force -ErrorAction SilentlyContinue
+        Import-Module $Global:CurrentSharePointStubModule -WarningAction SilentlyContinue 
+
+        Mock Remove-SPWOPIBinding {}
+        Mock New-SPWOPIBinding {}
+        Mock Set-SPWOPIZone {}
+        Mock Get-SPWOPIZone { return "internal-https" }
+        
+        Context "No bindings are set for the specified zone, but they should be" {
+            $testParams = @{
+                Zone    = "internal-https"
+                DnsName = "webapps.contoso.com"
+                Ensure  = "Present"
+            }
+
+            Mock Get-SPWOPIBinding {
+                return $null
+            }
+
+            It "should return absent from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent" 
+            }
+
+            It "should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "should create the bindings in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled New-SPWOPIBinding 
+                Assert-MockCalled Set-SPWOPIZone
+            }
+        }
+
+        Context "Incorrect bindings are set for the specified zone that should be configured" {
+            $testParams = @{
+                Zone    = "internal-https"
+                DnsName = "webapps.contoso.com"
+                Ensure  = "Present"
+            }
+
+            Mock Get-SPWOPIBinding {
+                return @(
+                    @{
+                        ServerName = "wrong.contoso.com"
+                    }
+                )
+            }
+
+            It "should return present from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Present"
+            }
+
+            It "should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "should remove the old bindings and create the new bindings in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled Remove-SPWOPIBinding
+                Assert-MockCalled New-SPWOPIBinding 
+                Assert-MockCalled Set-SPWOPIZone
+            }
+        }
+
+        Context "Correct bindings are set for the specified zone" {
+            $testParams = @{
+                Zone    = "internal-https"
+                DnsName = "webapps.contoso.com"
+                Ensure  = "Present"
+            }
+
+            Mock Get-SPWOPIBinding {
+                return @(
+                    @{
+                        ServerName = "webapps.contoso.com"
+                    }
+                )
+            }
+
+            It "should return present from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Present"
+            }
+
+            It "should return true from the test method" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
+
+        Context "Bindings are set for the specified zone, but they should not be" {
+            $testParams = @{
+                Zone    = "internal-https"
+                DnsName = "webapps.contoso.com"
+                Ensure  = "Absent"
+            }
+
+            Mock Get-SPWOPIBinding {
+                return @(
+                    @{
+                        ServerName = "webapps.contoso.com"
+                    }
+                )
+            }
+
+            It "should return present from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Present"
+            }
+
+            It "should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "should remove the bindings in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled Remove-SPWOPIBinding
+            }
+        } 
+
+        Context "Bindings are not set for the specified zone, and they should not be" {
+            $testParams = @{
+                Zone    = "internal-https"
+                DnsName = "webapps.contoso.com"
+                Ensure  = "Absent"
+            }
+
+            Mock Get-SPWOPIBinding {
+                return $null
+            }
+
+            It "should return absent from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+            }
+
+            It "should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
+    }    
+}


### PR DESCRIPTION
Fixes #212 

This new resource adds the ability to connect a farm to an Office Online Server 2016/Office Web Apps 2013 farm.

- [X] Change details added to Unreleased section of readme.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xsharepoint/317)
<!-- Reviewable:end -->
