### PR TITLE
Bugs with Access Services/Performance Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  * Improvement with SPInstallPrereqs on SPS2013 to accept 2008 R2 or 2012 SQL native client not only 2008 R2
  * Fixed a bug with SPTimerJobState that prevented a custom schedule being applied to a timer job
  * Fixed a bug with the detection of group principals vs. user principals in SPServiceAppSecurity and SPWebAppPolicy
+ * Fixed bugs in SPAccessServiceApp and SPPerformancePointServiceApp with type names not being identified correctly
+ * Added support for custom database name and server to SPPerformancePointServiceApp
 
 ### 1.0
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAccessServiceApp/MSFT_SPAccessServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAccessServiceApp/MSFT_SPAccessServiceApp.psm1
@@ -26,7 +26,7 @@ function Get-TargetResource
         if ($null -eq $serviceApps) { 
             return $nullReturn 
         }
-        $serviceApp = $serviceApps | Where-Object { $_.TypeName -eq "Access Services Application" }
+        $serviceApp = $serviceApps | Where-Object { $_.TypeName -eq "Access Services Web Service Application" }
 
         If ($null -eq $serviceApp) { 
             return $nullReturn 
@@ -73,7 +73,7 @@ function Set-TargetResource
         Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
                 $params = $args[0]
                 
-                $appService =  Get-SPServiceApplication -Name $params.Name | Where-Object { $_.TypeName -eq "Access Services Application"  }
+                $appService =  Get-SPServiceApplication -Name $params.Name | Where-Object { $_.TypeName -eq "Access Services Web Service Application"  }
                 Remove-SPServiceApplication $appService -Confirm:$false
             }
     }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.psm1
@@ -6,6 +6,8 @@ function Get-TargetResource
     (
         [parameter(Mandatory = $true)]  [System.String] $Name,
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
     )
@@ -25,7 +27,7 @@ function Get-TargetResource
         if ($null -eq $serviceApps) { 
             return $nullReturn 
         }
-        $serviceApp = $serviceApps | Where-Object { $_.TypeName -eq "Performance Point Service Application" }
+        $serviceApp = $serviceApps | Where-Object { $_.TypeName -eq "PerformancePoint Service Application" }
 
         if ($null -eq $serviceApp) { 
             return $nullReturn 
@@ -33,6 +35,8 @@ function Get-TargetResource
             return @{
                 Name = $serviceApp.DisplayName
                 ApplicationPool = $serviceApp.ApplicationPool.Name
+                DatabaseName = $serviceApp.Database.Name
+                DatabaseServer = $serviceApp.Database.Server.Name
                 Ensure = "Present"
             }
         }
@@ -47,6 +51,8 @@ function Set-TargetResource
     (
         [parameter(Mandatory = $true)]  [System.String] $Name,
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
     )
@@ -54,27 +60,38 @@ function Set-TargetResource
     $result = Get-TargetResource @PSBoundParameters
 
     if ($result.Ensure -eq "Absent" -and $Ensure -eq "Present") { 
-        Write-Verbose -Message "Creating Performance Point Service Application $Name"
+        Write-Verbose -Message "Creating PerformancePoint Service Application $Name"
         Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
             $params = $args[0]
-        
-            New-SPPerformancePointServiceApplication -Name $params.Name `
-                                                     -ApplicationPool $params.ApplicationPool
 
-            New-SPPerformancePointServiceApplicationProxy -Name $params.Name `
+            $newParams = @{
+                Name = $params.Name
+                ApplicationPool = $params.ApplicationPool
+            }
+            if ($params.ContainsKey("DatabaseName") -eq $true) 
+            {
+                $newParams.Add("DatabaseName", $params.DatabaseName)
+            }
+            if ($params.ContainsKey("DatabaseServer") -eq $true) 
+            {
+                $newParams.Add("DatabaseServer", $params.DatabaseServer)
+            }
+        
+            New-SPPerformancePointServiceApplication @newParams
+            New-SPPerformancePointServiceApplicationProxy -Name "$($params.Name) Proxy" `
                                                           -ServiceApplication $params.Name 
         }
     }
     if ($result.Ensure -eq "Present" -and $Ensure -eq "Present") {
         if ($ApplicationPool -ne $result.ApplicationPool) {
-            Write-Verbose -Message "Updating Performance Point Service Application $Name"
+            Write-Verbose -Message "Updating PerformancePoint Service Application $Name"
             Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
                 $params = $args[0]               
 
                 $appPool = Get-SPServiceApplicationPool -Identity $params.ApplicationPool
 
                 Get-SPServiceApplication -Name $params.Name `
-                    | Where-Object { $_.TypeName -eq "Performance Point Service Application" } `
+                    | Where-Object { $_.TypeName -eq "PerformancePoint Service Application" } `
                     | Set-SPPerformancePointServiceApplication -ApplicationPool $appPool
             }
         }
@@ -84,7 +101,7 @@ function Set-TargetResource
         Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
                 $params = $args[0]
                 
-                $appService =  Get-SPServiceApplication -Name $params.Name | Where-Object { $_.TypeName -eq "Performance Point Service Application"  }
+                $appService =  Get-SPServiceApplication -Name $params.Name | Where-Object { $_.TypeName -eq "PerformancePoint Service Application"  }
                 Remove-SPServiceApplication $appService -Confirm:$false
             }
     }
@@ -98,11 +115,13 @@ function Test-TargetResource
     (
         [parameter(Mandatory = $true)]  [System.String] $Name,
         [parameter(Mandatory = $true)]  [System.String] $ApplicationPool,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseName,
+        [parameter(Mandatory = $false)] [System.String] $DatabaseServer,
         [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
         [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
     )
     
-    Write-Verbose -Message "Testing for Performance Point Service Application '$Name'"
+    Write-Verbose -Message "Testing for PerformancePoint Service Application '$Name'"
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $PSBoundParameters.Ensure = $Ensure
     return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("ApplicationPool", "Ensure")

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.schema.mof
@@ -16,6 +16,8 @@ class MSFT_SPPerformancePointServiceApp : OMI_BaseResource
 {
     [Key, Description("The name of the service application")] string Name;
     [Required, Description("The name of the application pool to run the service app in")] string ApplicationPool;
+    [Write, Description("The name of the database for the service app")] string DatabaseName;
+    [Write, Description("The name of the database server to host the database")] string DatabaseServer;
     [Write, Description("Present ensures service app exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/Tests/SharePointDsc/SharePointDsc.SPAccessServiceApp.Tests.ps1
+++ b/Tests/SharePointDsc/SharePointDsc.SPAccessServiceApp.Tests.ps1
@@ -65,7 +65,7 @@ Describe "SPAccessServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
         Context "When a service application exists and is configured correctly" {
             Mock Get-SPServiceApplication { 
                 return @(@{
-                    TypeName = "Access Services Application"
+                    TypeName = "Access Services Web Service Application"
                     DisplayName = $testParams.Name
                     DatabaseServer = $testParams.DatebaseName
                     ApplicationPool = @{ Name = $testParams.ApplicationPool }
@@ -90,7 +90,7 @@ Describe "SPAccessServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
         Context "When the service application exists but it shouldn't" {
             Mock Get-SPServiceApplication { 
                 return @(@{
-                    TypeName = "Access Services Application"
+                    TypeName = "Access Services Web Service Application"
                     DisplayName = $testParams.Name
                     DatabaseServer = $testParams.DatabaseServer
                     ApplicationPool = @{ Name = $testParams.ApplicationPool }

--- a/Tests/SharePointDsc/SharePointDsc.SPPerformancePointServiceApp.Tests.ps1
+++ b/Tests/SharePointDsc/SharePointDsc.SPPerformancePointServiceApp.Tests.ps1
@@ -64,7 +64,7 @@ Describe "SPPerformancePointServiceApp - SharePoint Build $((Get-Item $SharePoin
         Context "When a service application exists and is configured correctly" {
             Mock Get-SPServiceApplication { 
                 return @(@{
-                    TypeName = "Performance Point Service Application"
+                    TypeName = "PerformancePoint Service Application"
                     DisplayName = $testParams.Name
                     ApplicationPool = @{ Name = $testParams.ApplicationPool }
                 })
@@ -82,7 +82,7 @@ Describe "SPPerformancePointServiceApp - SharePoint Build $((Get-Item $SharePoin
         Context "When a service application exists and is not configured correctly" {
             Mock Get-SPServiceApplication { 
                 return @(@{
-                    TypeName = "Performance Point Service Application"
+                    TypeName = "PerformancePoint Service Application"
                     DisplayName = $testParams.Name
                     ApplicationPool = @{ Name = "Wrong App Pool Name" }
                 })
@@ -108,7 +108,7 @@ Describe "SPPerformancePointServiceApp - SharePoint Build $((Get-Item $SharePoin
         Context "When the service application exists but it shouldn't" {
             Mock Get-SPServiceApplication { 
                 return @(@{
-                    TypeName = "Performance Point Service Application"
+                    TypeName = "PerformancePoint Service Application"
                     DisplayName = $testParams.Name
                     ApplicationPool = @{ Name = $testParams.ApplicationPool }
                 })


### PR DESCRIPTION
A couple of quick fixes to address issues:

 * Access and PerformancePoint both had an incorrect type name in code, resulting in constant false test results
 * PerformancePoint didn't have database name parameters, which in tandem with the above issue meant that you would see a new performance point service app created every time the DSC ran

- [X] Change details added to Unreleased section of readme.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/326)
<!-- Reviewable:end -->
