### PR TITLE
Fixed bug with URL property of SPAlternateUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * Improvement with SPInstallPrereqs on SPS2013 to accept 2008 R2 or 2012 SQL native client not only 2008 R2
  * Fixed a bug with SPTimerJobState that prevented a custom schedule being applied to a timer job
  * Fixed a bug with the detection of group principals vs. user principals in SPServiceAppSecurity and SPWebAppPolicy
+ * Fixed a buy with SPAlternateUrl that prevented the test method from returning "true" when a URL was absent if the optional URL property was specified in the config
 
 ### 1.0
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
@@ -107,6 +107,14 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     Write-Verbose -Message "Testing alternate URL configuration"
-    return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Url", "Ensure") 
+    if ($Ensure -eq "Present")
+    {
+        return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Url", "Ensure")
+    }
+    else 
+    {
+        return Test-SPDSCSpecificParameters -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Ensure")
+    }
+     
 }
 

--- a/Tests/SharePointDsc/SharePointDsc.SPAlternateUrl.Tests.ps1
+++ b/Tests/SharePointDsc/SharePointDsc.SPAlternateUrl.Tests.ps1
@@ -100,7 +100,7 @@ Describe "SPAlternateUrl - SharePoint Build $((Get-Item $SharePointCmdletModule)
             }
         }
 
-        Context "A URL exists for the specified zone and web app, and it is correct" {
+        Context "A URL exists for the specified zone and web app, and it should not" {
             
             Mock Get-SPAlternateUrl {
                 return @(
@@ -121,6 +121,26 @@ Describe "SPAlternateUrl - SharePoint Build $((Get-Item $SharePointCmdletModule)
                 Set-TargetResource @testParams
                 Assert-MockCalled Remove-SPAlternateURL
             }
+        }
+
+        Context "A URL does not exist for the current zone, and it should not" {
+
+            Mock Get-SPAlternateUrl {
+                return @()
+            } 
+
+            it "returns the empty values in the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+            }
+
+            it "returns true from the test method" {
+                Test-targetResource @testParams | Should Be $true
+            }
+            $testParams.Remove("Url")
+            it "still returns true from the test method with the URL property not providing" {
+                Test-targetResource @testParams | Should Be $true
+            }
+            $testParams.Add("Url", "http://something.contoso.local")
         }
         
         Context "The default zone URL for a web app was changed using this resource" {


### PR DESCRIPTION
A quick fix here - the scenario is that if you use SPAlternateUrl, set to absent but still specify the URL property anyway, the test method will always return false. The URL property isn't mandatory and should be ignored in this scenario, this PR corrects that.

- [X] Change details added to Unreleased section of readme.md?
- [n/a] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/327)
<!-- Reviewable:end -->
