### PR TITLE
Fixed bug with SPSearchServiceApp to allow mangement of default crawl account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * Fixed bugs in SPAccessServiceApp and SPPerformancePointServiceApp with type names not being identified correctly
  * Added support for custom database name and server to SPPerformancePointServiceApp
  * Added solution level property to SPFarmSolution
+ * Fixed a bug with SPSearchServiceApp that prevents the default crawl account from being managed after it is initially set
 
 ### 1.0
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchServiceApp/MSFT_SPSearchServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchServiceApp/MSFT_SPSearchServiceApp.psm1
@@ -1,5 +1,7 @@
 function Get-TargetResource
 {
+    # Ignoring this because we need to generate a stub credential to return up the current crawl account as a PSCredential
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])] 
     param
@@ -45,8 +47,13 @@ function Get-TargetResource
         if ($null -eq $serviceApp) { 
             return $nullReturn
         } else {
-            $defaultAccount = Get-SPDSCContentAccessAccount
-            
+            $caWebApp = Get-SPWebApplication -IncludeCentralAdministration | Where-Object -FilterScript { $_.IsAdministrationWebApplication } 
+            $s = Get-SPSite $caWebApp.Url
+            $c = [Microsoft.Office.Server.Search.Administration.SearchContext]::GetContext($s);
+            $sc = New-Object -TypeName Microsoft.Office.Server.Search.Administration.Content -ArgumentList $c;
+            $dummyPassword = ConvertTo-SecureString "-" -AsPlainText -Force
+            $defaultAccount = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($sc.DefaultGatheringAccount, $dummyPassword)
+
             $cloudIndex = $false
             $version = Get-SPDSCInstalledProductVersion
             if(($version.FileMajorPart -gt 15) -or ($version.FileMajorPart -eq 15 -and $version.FileBuildPart -ge 4745)) {

--- a/Tests/SharePointDsc/SharePointDsc.SPSearchServiceApp.Tests.ps1
+++ b/Tests/SharePointDsc/SharePointDsc.SPSearchServiceApp.Tests.ps1
@@ -56,9 +56,11 @@ Describe "SPSearchServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
             }) }
             Mock Get-SPSite { @{} }
             
-            Mock Get-SPDSCContentAccessAccount {
-                return (New-Object System.Management.Automation.PSCredential ("Domain\username", (ConvertTo-SecureString "password" -AsPlainText -Force)))
-            }
+            Mock New-Object {
+                return @{
+                    DefaultGatheringAccount = "Domain\username"
+                }
+            } -ParameterFilter { $TypeName -eq "Microsoft.Office.Server.Search.Administration.Content" }
             
             Mock Import-Module {} -ParameterFilter { $_.Name -eq $ModuleName }
 
@@ -174,10 +176,12 @@ Describe "SPSearchServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
                 })
             }
             
-            Mock Get-SPDSCContentAccessAccount {
-                return (New-Object System.Management.Automation.PSCredential ("DOESNOT\match", (ConvertTo-SecureString "password" -AsPlainText -Force)))
-            }
-            
+            Mock New-Object {
+                return @{
+                    DefaultGatheringAccount = "WRONG\username"
+                }
+            } -ParameterFilter { $TypeName -eq "Microsoft.Office.Server.Search.Administration.Content" }
+
             It "returns false from the test method" {
                 Test-TargetResource @testParams | Should Be $false
             }
@@ -203,9 +207,11 @@ Describe "SPSearchServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
                 })
             }
             
-            Mock Get-SPDSCContentAccessAccount {
-                return (New-Object System.Management.Automation.PSCredential ("DOMAIN\username", (ConvertTo-SecureString "password" -AsPlainText -Force)))
-            }
+            Mock New-Object {
+                return @{
+                    DefaultGatheringAccount = "Domain\username"
+                }
+            } -ParameterFilter { $TypeName -eq "Microsoft.Office.Server.Search.Administration.Content" }
             
             It "returns true from the test method" {
                 Test-TargetResource @testParams | Should Be $true
@@ -243,9 +249,11 @@ Describe "SPSearchServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
             }) }
             Mock Get-SPSite { @{} }
             
-            Mock Get-SPDSCContentAccessAccount {
-                return (New-Object System.Management.Automation.PSCredential ("DOMAIN\username", (ConvertTo-SecureString "password" -AsPlainText -Force)))
-            }
+            Mock New-Object {
+                return @{
+                    DefaultGatheringAccount = "Domain\username"
+                }
+            } -ParameterFilter { $TypeName -eq "Microsoft.Office.Server.Search.Administration.Content" }
             
             It "should return false from the test method" {
                 Test-TargetResource @testParams | Should Be $false
@@ -284,9 +292,11 @@ Describe "SPSearchServiceApp - SharePoint Build $((Get-Item $SharePointCmdletMod
             }) }
             Mock Get-SPSite { @{} }
             
-            Mock Get-SPDSCContentAccessAccount {
-                return (New-Object System.Management.Automation.PSCredential ("DOMAIN\username", (ConvertTo-SecureString "password" -AsPlainText -Force)))
-            }
+            Mock New-Object {
+                return @{
+                    DefaultGatheringAccount = "Domain\username"
+                }
+            } -ParameterFilter { $TypeName -eq "Microsoft.Office.Server.Search.Administration.Content" }
             
             It "should return true from the test method" {
                 Test-TargetResource @testParams | Should Be $true


### PR DESCRIPTION
Fixes a quick bug where a defautl crawl account would not be reported correctly, causing an error in the get method.

- [X] Change details added to Unreleased section of readme.md?
- [n/a] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/337)
<!-- Reviewable:end -->
