### PR TITLE
Removed Win32_Product from SPInstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  * Added better logging to all test method output to make it clear what property is causing a test to fail
  * Added support for NetBIOS domain names resolution to SPUserProfileServiceApp
  * Removed chocolatey from the AppVeyor build process in favour of the PowerShell Gallery build of Pester
+ * Removed dependency on Win32_Product from SPInstall
 
 ### 1.1
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
@@ -4,17 +4,43 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $BinaryDir,
-        [parameter(Mandatory = $true)]  [System.String] $ProductKey,
-        [parameter(Mandatory = $false)] [System.String] $InstallPath,
-        [parameter(Mandatory = $false)] [System.String] $DataPath,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present"
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $BinaryDir,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $ProductKey,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $InstallPath,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $DataPath,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present"
     )
 
     Write-Verbose -Message "Getting install status of SP binaries"
+    $x86Path = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    $installedItemsX86 = Get-ItemProperty -Path $x86Path | Select-Object -Property DisplayName
+    
+    $x64Path = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    $installedItemsX64 = Get-ItemProperty -Path $x64Path | Select-Object -Property DisplayName
 
-    $spInstall = Get-CimInstance -ClassName Win32_Product -Filter "Name like 'Microsoft SharePoint Server%'"
-    if ($spInstall) {
+    $installedItems = $installedItemsX86 + $installedItemsX64 
+    $installedItems = $installedItems | Select-Object -Property DisplayName -Unique    
+    $spInstall = $installedItems | Where-Object -FilterScript { 
+        $_ -match "Microsoft SharePoint Server (2013|2016)" 
+    }
+
+    if ($spInstall) 
+    {
         return @{
             BinaryDir = $BinaryDir
             ProductKey = $ProductKey
@@ -22,7 +48,9 @@ function Get-TargetResource
             DataPath = $DataPath
             Ensure = "Present"
         }
-    } else {
+    } 
+    else 
+    {
         return @{
             BinaryDir = $BinaryDir
             ProductKey = $ProductKey
@@ -39,24 +67,49 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $BinaryDir,
-        [parameter(Mandatory = $true)]  [System.String] $ProductKey,
-        [parameter(Mandatory = $false)] [System.String] $InstallPath,
-        [parameter(Mandatory = $false)] [System.String] $DataPath,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present"
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $BinaryDir,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $ProductKey,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $InstallPath,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $DataPath,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present"
     )
 
-    if ($Ensure -eq "Absent") {
-        throw [Exception] "SharePointDsc does not support uninstalling SharePoint or its prerequisites. Please remove this manually."
+    if ($Ensure -eq "Absent") 
+    {
+        throw [Exception] ("SharePointDsc does not support uninstalling SharePoint or " + `
+                           "its prerequisites. Please remove this manually.")
         return
     }
     
     $InstallerPath = Join-Path $BinaryDir "setup.exe"
     $majorVersion = (Get-SPDSCAssemblyVersion -PathToAssembly $InstallerPath)
-    if ($majorVersion -eq 15) {
-        $dotNet46Check = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP' -recurse | Get-ItemProperty -name Version,Release -EA 0 | Where-Object -FilterScript { $_.PSChildName -match '^(?!S)\p{L}' -and $_.Version -like "4.6.*"}
-        if ($null -ne $dotNet46Check -and $dotNet46Check.Length -gt 0) {
-            throw [Exception] "A known issue prevents installation of SharePoint 2013 on servers that have .NET 4.6 already installed. See details at https://support.microsoft.com/en-us/kb/3087184"
+    if ($majorVersion -eq 15) 
+    {
+        $ndp = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP'
+        $dotNet46Check = $ndp | Get-ItemProperty -name Version,Release -EA 0 `
+                              | Where-Object -FilterScript { 
+                                  $_.PSChildName -match '^(?!S)\p{L}' -and $_.Version -like "4.6.*"
+                                }
+        if ($null -ne $dotNet46Check -and $dotNet46Check.Length -gt 0) 
+        {
+            throw [Exception] ("A known issue prevents installation of SharePoint 2013 on " + `
+                               "servers that have .NET 4.6 already installed. See details " + `
+                               "at https://support.microsoft.com/en-us/kb/3087184")
             return
         }    
     }
@@ -79,11 +132,13 @@ function Set-TargetResource
     <Display Level=`"none`" CompletionNotice=`"no`" />
 "
 
-    if ($PSBoundParameters.ContainsKey("InstallPath") -eq $true) {
+    if ($PSBoundParameters.ContainsKey("InstallPath") -eq $true) 
+    {
         $configData += "    <INSTALLLOCATION Value=`"$InstallPath`" />
 "
     }
-    if ($PSBoundParameters.ContainsKey("DataPath") -eq $true) {
+    if ($PSBoundParameters.ContainsKey("DataPath") -eq $true) 
+    {
         $configData += "    <DATADIR Value=`"$DataPath`"/>
 "
     }
@@ -99,23 +154,35 @@ function Set-TargetResource
     
     $setupExe = Join-Path -Path $BinaryDir -ChildPath "setup.exe"
     
-    $setup = Start-Process -FilePath $setupExe -ArgumentList "/config `"$configPath`"" -Wait -PassThru
+    $setup = Start-Process -FilePath $setupExe `
+                           -ArgumentList "/config `"$configPath`"" `
+                           -Wait `
+                           -PassThru
 
-    switch ($setup.ExitCode) {
+    switch ($setup.ExitCode) 
+    {
         0 {  
             Write-Verbose -Message "SharePoint binary installation complete"
             $global:DSCMachineStatus = 1
         }
         30066 {
-            if (    ($null -ne (Get-Item 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending' -ErrorAction SilentlyContinue)) `
-                -or ($null -ne (Get-Item 'HKLM:\Software\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' -ErrorAction SilentlyContinue)) `
-                -or ((Get-Item 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' | Get-ItemProperty).PendingFileRenameOperations.count -gt 0) `
+            $pr1 = ("HKLM:\Software\Microsoft\Windows\CurrentVersion\" + `
+                    "Component Based Servicing\RebootPending")
+            $pr2 = ("HKLM:\Software\Microsoft\Windows\CurrentVersion\" + `
+                    "WindowsUpdate\Auto Update\RebootRequired")
+            $pr3 = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"
+            if (    ($null -ne (Get-Item $pr1 -ErrorAction SilentlyContinue)) `
+                -or ($null -ne (Get-Item $pr2 -ErrorAction SilentlyContinue)) `
+                -or ((Get-Item $pr3 | Get-ItemProperty).PendingFileRenameOperations.count -gt 0) `
                 ) {
                     
-                Write-Verbose -Message "xSPInstall has detected the server has pending a reboot. Flagging to the DSC engine that the server should reboot before continuing."
+                Write-Verbose -Message ("xSPInstall has detected the server has pending " + `
+                                        "a reboot. Flagging to the DSC engine that the " + `
+                                        "server should reboot before continuing.")
                 $global:DSCMachineStatus = 1
             } else {
-                throw "SharePoint installation has failed due to an issue with prerequisites not being installed correctly. Please review the setup logs."
+                throw ("SharePoint installation has failed due to an issue with prerequisites " + `
+                       "not being installed correctly. Please review the setup logs.")
             }
         }
         Default {
@@ -131,15 +198,32 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $BinaryDir,
-        [parameter(Mandatory = $true)]  [System.String] $ProductKey,
-        [parameter(Mandatory = $false)] [System.String] $InstallPath,
-        [parameter(Mandatory = $false)] [System.String] $DataPath,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present"
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $BinaryDir,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $ProductKey,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $InstallPath,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        $DataPath,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present"
     )
 
-    if ($Ensure -eq "Absent") {
-        throw [Exception] "SharePointDsc does not support uninstalling SharePoint or its prerequisites. Please remove this manually."
+    if ($Ensure -eq "Absent") 
+    {
+        throw [Exception] ("SharePointDsc does not support uninstalling SharePoint or " + `
+                           "its prerequisites. Please remove this manually.")
         return
     }
 
@@ -148,7 +232,9 @@ function Test-TargetResource
 
     Write-Verbose -Message "Testing for installation of SharePoint"
 
-    return Test-SPDscParameterState -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("Ensure")
+    return Test-SPDscParameterState -CurrentValues $CurrentValues `
+                                    -DesiredValues $PSBoundParameters `
+                                    -ValuesToCheck @("Ensure")
 }
 
 Export-ModuleMember -Function *-TargetResource


### PR DESCRIPTION
Quick fix to something that should have happened in 1.1 when we removed Win32_Product from SPInstallPrereqs. I also made style changes to bring SPInstall in line as well. 

- [X] Change details added to Unreleased section of changelog.md?
- [n/a] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/367)
<!-- Reviewable:end -->
