### PR TITLE
Added SPRemoteFarmTrust resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
  * Added better logging to all test method output to make it clear what property is causing a test to fail
  * Added support for NetBIOS domain names resolution to SPUserProfileServiceApp
  * Removed chocolatey from the AppVeyor build process in favour of the PowerShell Gallery build of Pester
- * Added resource MSFT_SPTrustedIdentityTokenIssuer
+ * Added SPTrustedIdentityTokenIssuer and SPRemoteFarmTrust resources
 
 ### 1.1
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.psm1
@@ -1,0 +1,209 @@
+function Get-TargetResource()
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.HashTable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $RemoteWebAppUrl,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $LocalWebAppUrl,
+
+        [Parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] $Ensure = "Present",
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    Write-Verbose -Message "Looking for remote farm trust '$Name'"
+
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+                                  -Arguments $PSBoundParameters `
+                                  -ScriptBlock {
+        $params = $args[0]
+
+        $returnValue = @{
+            Name = $params.Name
+            RemoteWebAppUrl = $params.RemoteWebAppUrl
+            LocalWebAppUrl = $params.LocalWebAppUrl
+            Ensure = "Absent"
+            InstallAccount = $params.InstallAccount
+        }
+
+        $issuer = Get-SPTrustedSecurityTokenIssuer -Identity $params.Name `
+                                                   -ErrorAction SilentlyContinue
+        if ($null -eq $issuer)
+        {
+            return $returnValue
+        }
+        $rootAuthority = Get-SPTrustedRootAuthority -Identity $params.Name `
+                                                    -ErrorAction SilentlyContinue
+        if ($null -eq $rootAuthority)
+        {
+            return $returnValue
+        }
+        $realm = $issuer.NameId.Split("@")
+        $site = Get-SPSite -Identity $params.LocalWebAppUrl
+        $serviceContext = Get-SPServiceContext -Site $site
+        $currentRealm = Get-SPAuthenticationRealm -ServiceContext $serviceContext
+
+        if ($realm[1] -ne $currentRealm)
+        {
+            return $returnValue
+        }
+        $returnValue.Ensure = "Present"
+        return $returnValue
+    }
+    return $result    
+}
+
+function Set-TargetResource()
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $RemoteWebAppUrl,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $LocalWebAppUrl,
+
+        [Parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] $Ensure = "Present",
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    if ($Ensure -eq "Present")
+    {
+        Write-Verbose -Message "Adding remote farm trust '$Name'"
+
+        Invoke-SPDSCCommand -Credential $InstallAccount `
+                            -Arguments $PSBoundParameters `
+                            -ScriptBlock {
+            $params = $args[0]
+            $remoteWebApp = $params.RemoteWebAppUrl.TrimEnd('/')
+
+            $issuer = Get-SPTrustedSecurityTokenIssuer -Identity $params.Name `
+                                                       -ErrorAction SilentlyContinue
+            if ($null -eq $issuer)
+            {
+                $endpoint = "$remoteWebApp/_layouts/15/metadata/json/1"
+                $issuer = New-SPTrustedSecurityTokenIssuer -Name $params.Name `
+                                                           -IsTrustBroker:$false `
+                                                           -MetadataEndpoint $endpoint
+            }
+
+            $rootAuthority = Get-SPTrustedRootAuthority -Identity $params.Name `
+                                                        -ErrorAction SilentlyContinue
+            if ($null -eq $rootAuthority)
+            {
+                $endpoint = "$remoteWebApp/_layouts/15/metadata/json/1/rootcertificate"
+                New-SPTrustedRootAuthority -Name $params.Name `
+                                           -MetadataEndPoint $endpoint
+            }
+            $realm = $issuer.NameId.Split("@")
+            $site = Get-SPSite -Identity $params.LocalWebAppUrl
+            $serviceContext = Get-SPServiceContext -Site $site
+            $currentRealm = Get-SPAuthenticationRealm -ServiceContext $serviceContext `
+                                                      -ErrorAction SilentlyContinue
+
+            if ($realm[1] -ne $currentRealm)
+            {
+                Set-SPAuthenticationRealm -ServiceContext $serviceContext -Realm $realm[1]    
+            }
+
+            $appPrincipal = Get-SPAppPrincipal -Site $params.LocalWebAppUrl `
+                                               -NameIdentifier $issuer.NameId
+
+            Set-SPAppPrincipalPermission -Site $params.LocalWebAppUrl `
+                                         -AppPrincipal $appPrincipal `
+                                         -Scope SiteCollection `
+                                         -Right FullControl
+        }
+    }
+    
+    if ($Ensure -eq "Absent")
+    {
+        Write-Verbose -Message "Removing remote farm trust '$Name'"
+
+        Invoke-SPDSCCommand -Credential $InstallAccount `
+                            -Arguments $PSBoundParameters `
+                            -ScriptBlock {
+            $params = $args[0]
+            $remoteWebApp = $params.RemoteWebAppUrl.TrimEnd('/')
+
+            $issuer = Get-SPTrustedSecurityTokenIssuer -Identity $params.Name `
+                                                       -ErrorAction SilentlyContinue
+            if ($null -ne $issuer)
+            {
+                $appPrincipal = Get-SPAppPrincipal -Site $params.LocalWebAppUrl `
+                                                   -NameIdentifier $issuer.NameId
+                Remove-SPAppPrincipalPermission -Site $params.LocalWebAppUrl `
+                                                -AppPrincipal $appPrincipal `
+                                                -Scope SiteCollection `
+                                                -Confirm:$false
+            }
+            
+            Get-SPTrustedRootAuthority -Identity $params.Name `
+                                       -ErrorAction SilentlyContinue `
+                                       | Remove-SPTrustedRootAuthority -Confirm:$false
+            if ($null -ne $issuer)
+            {
+                $issuer | Remove-SPTrustedSecurityTokenIssuer -Confirm:$false
+            }
+        }
+    }
+}
+
+function Test-TargetResource()
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $RemoteWebAppUrl,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $LocalWebAppUrl,
+
+        [Parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] $Ensure = "Present",
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+
+    return Test-SPDscParameterState -CurrentValues $CurrentValues `
+                                    -DesiredValues $PSBoundParameters `
+                                    -ValuesToCheck @("Ensure")
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.schema.mof
@@ -1,0 +1,25 @@
+/*
+**Description**
+
+This resource is used to configure quota templates in the farm.
+These settings will be used to make sure a certain quota template exists or not. When it exists, it will also make sure the settings are configured as specified.
+
+**Example**
+
+    SPRemoteFarmTrust TrustRemoteFarmForSearch
+    {
+        Name = "CentralSearchFarm"
+        RemoteWebAppUrl = "https://search.sharepoint.contoso.com"
+        LocalWebAppUrl = "https://local.sharepoint2.contoso.com"
+    }
+*/
+
+[ClassVersion("1.0.0.0"), FriendlyName("SPRemoteFarmTrust")]
+class MSFT_SPRemoteFarmTrust : OMI_BaseResource
+{
+    [Key, Description("A name of the remote farm, used to create token issuer and root authority")] string Name;
+    [Required, Description("The URL of a web app in the remote farm, must use HTTPS")] string RemoteWebAppUrl;
+    [Required, Description("The URL of a local web app to connect the remote farm to")] string LocalWebAppUrl;
+    [Write, Description("Set to present to ensure the trust exists, or absent to ensure it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+};

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPRemoteFarmTrust/MSFT_SPRemoteFarmTrust.schema.mof
@@ -1,8 +1,9 @@
 /*
 **Description**
 
-This resource is used to configure quota templates in the farm.
-These settings will be used to make sure a certain quota template exists or not. When it exists, it will also make sure the settings are configured as specified.
+This resource is used to trust a remote SharePoint farm.
+This is used when federating search results between two different SharePoint farms.
+The technique is described at https://technet.microsoft.com/en-us/library/dn133749.aspx
 
 **Example**
 

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPRemoteFarmTrust.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPRemoteFarmTrust.Tests.ps1
@@ -1,0 +1,165 @@
+[CmdletBinding()]
+param(
+    [string] $SharePointCmdletModule = (Join-Path $PSScriptRoot "..\Stubs\SharePoint\15.0.4805.1000\Microsoft.SharePoint.PowerShell.psm1" -Resolve)
+)
+
+$ErrorActionPreference = 'stop'
+Set-StrictMode -Version latest
+
+$RepoRoot = (Resolve-Path $PSScriptRoot\..\..\..).Path
+$Global:CurrentSharePointStubModule = $SharePointCmdletModule 
+
+$ModuleName = "MSFT_SPRemoteFarmTrust"
+Import-Module (Join-Path $RepoRoot "Modules\SharePointDsc\DSCResources\$ModuleName\$ModuleName.psm1") -Force
+
+Describe "SPRemoteFarmTrust - SharePoint Build $((Get-Item $SharePointCmdletModule).Directory.BaseName)" {
+    InModuleScope $ModuleName {
+        $testParams = @{
+            Name = "SendingFarm"
+            LocalWebAppUrl = "https://sharepoint.adventureworks.com"
+            RemoteWebAppUrl = "https://sharepoint.contoso.com"
+            Ensure = "Present"
+        }
+        Import-Module (Join-Path ((Resolve-Path $PSScriptRoot\..\..\..).Path) "Modules\SharePointDsc")
+        
+        Mock Invoke-SPDSCCommand { 
+            return Invoke-Command -ScriptBlock $ScriptBlock -ArgumentList $Arguments -NoNewScope
+        }
+        
+        Remove-Module -Name "Microsoft.SharePoint.PowerShell" -Force -ErrorAction SilentlyContinue        
+        Import-Module $Global:CurrentSharePointStubModule -WarningAction SilentlyContinue
+
+        Mock Get-SPSite {
+            return @{
+                Url = $Identity
+            }
+        }
+        Mock Get-SPServiceContext {
+            return @{
+                Site = $Site
+            }
+        }
+        Mock Get-SPAuthenticationRealm {
+            return "14757a87-4d74-4323-83b9-fb1e77e8f22f"
+        }
+        Mock Get-SPAppPrincipal {
+            return @{
+                Site = $Site
+            }
+        }
+        Mock Set-SPAuthenticationRealm {}
+        Mock Set-SPAppPrincipalPermission {}
+        Mock Remove-SPAppPrincipalPermission {}
+        Mock Remove-SPTrustedRootAuthority {}
+        Mock Remove-SPTrustedSecurityTokenIssuer {}
+        Mock New-SPTrustedSecurityTokenIssuer {
+            return @{
+                NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+            }
+        }
+        Mock New-SPTrustedRootAuthority {
+            return @{
+                NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+            }
+        }
+
+
+        Context "A remote farm trust doesn't exist, but should" {
+
+            Mock Get-SPTrustedSecurityTokenIssuer {
+                return $null
+            }
+            Mock Get-SPTrustedRootAuthority {
+                return $null
+            }
+
+            It "returns absent from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+            }
+
+            It "returns false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "adds the trust in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled -CommandName New-SPTrustedSecurityTokenIssuer
+                Assert-MockCalled -CommandName New-SPTrustedRootAuthority
+            }
+        }
+
+        Context "A remote farm trust exists and should" {
+
+            Mock Get-SPTrustedSecurityTokenIssuer {
+                return @(
+                    @{
+                        NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+                    }
+                )
+            }
+            Mock Get-SPTrustedRootAuthority {
+                return @{
+                    NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+                }
+            }
+
+            It "returns present from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Present"
+            }
+
+            It "returns true from the test method" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
+
+        $testParams.Ensure = "Absent"
+
+        Context "A remote farm trust exists and shouldn't" {
+
+            Mock Get-SPTrustedSecurityTokenIssuer {
+                return @(
+                    @{
+                        NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+                    }
+                )
+            }
+            Mock Get-SPTrustedRootAuthority {
+                return @{
+                    NameId = "f5a433c7-69f9-48ef-916b-dde8b5fa6fdb@14757a87-4d74-4323-83b9-fb1e77e8f22f"
+                }
+            }
+
+            It "returns present from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Present"
+            }
+
+            It "returns false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "removes the trust in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled -CommandName Remove-SPTrustedSecurityTokenIssuer
+                Assert-MockCalled -CommandName Remove-SPTrustedRootAuthority
+            }
+        }
+
+        Context "A remote farm trust doesn't exist and shouldn't" {
+
+            Mock Get-SPTrustedSecurityTokenIssuer {
+                return $null
+            }
+            Mock Get-SPTrustedRootAuthority {
+                return $null
+            }
+
+            It "returns absent from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+            }
+
+            It "returns true from the test method" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a SPRemoteFarmTrust resource - this is used when trusting a remote farm for things such as federating search (as described at https://technet.microsoft.com/en-us/library/dn133749.aspx)

I've not added this to the main examples as its more of a niche thing, and when the revamped examples are done they will be added in for a resource specific example at that point.

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/368)
<!-- Reviewable:end -->
