### PR TITLE
Missing required parameter in example SPOutgoingEmailSettings

### DIFF
--- a/Modules/SharePointDsc/DSCResources/MSFT_SPOutgoingEmailSettings/MSFT_SPOutgoingEmailSettings.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPOutgoingEmailSettings/MSFT_SPOutgoingEmailSettings.schema.mof
@@ -13,6 +13,7 @@ It is possible to set the outgoing server, from address, reply to address and th
         SMTPServer            = "smtp.contoso.com"
         FromAddress           = "sharepoint@contoso.com"
         ReplyToAddress        = "noreply@contoso.com"
+        CharacterSet          = "65001"
         PsDscRunAsCredential  = $InstallAccount
     }
 */


### PR DESCRIPTION
Missing required parameter CharacterSet in SPOutgoingEmailSettings example

- [ ] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/369)
<!-- Reviewable:end -->
