### PR TITLE
Added HostHeader parameters to Web application examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * Fixed the use of plural nouns in cmdlet names within the module
  * Removed dependency on Win32_Product from SPInstall
  * Added SPTrustedIdentityTokenIssuer and SPRemoteFarmTrust resources
+ * Added HostHeader parameter in examples for Web Application, so subsequent web applications won't error out 
 
 ### 1.1
 

--- a/Modules/SharePointDsc/Examples/Single Server/SharePoint.ps1
+++ b/Modules/SharePointDsc/Examples/Single Server/SharePoint.ps1
@@ -173,6 +173,7 @@ Configuration SharePointServer
                 DatabaseName           = $webApp.DatabaseName
                 DatabaseServer         = $ConfigurationData.NonNodeData.SQLServer.ContentDatabaseServer
                 Url                    = $webApp.Url
+                HostHeader             = $webApp.HostHeader
                 Port                   = [Uri]::new($webApp.Url).Port
                 PsDscRunAsCredential   = $SPSetupAccount
                 DependsOn              = "[SPManagedAccount]WebPoolManagedAccount"

--- a/Modules/SharePointDsc/Examples/Single Server/SharePoint.psd1
+++ b/Modules/SharePointDsc/Examples/Single Server/SharePoint.psd1
@@ -53,6 +53,7 @@
                     Name = "SharePoint Sites"
                     DatabaeName = "SP_Content_01"
                     Url = "http://sites.sharepoint.contoso.local"
+                    HostHeader = "sites.sharepoint.contoso.local"
                     Authentication = "NTLM"
                     Anonymous = $false
                     AppPool = "SharePoint Sites"

--- a/Modules/SharePointDsc/Examples/Small Farm/SharePoint.ps1
+++ b/Modules/SharePointDsc/Examples/Small Farm/SharePoint.ps1
@@ -281,6 +281,7 @@ Configuration SharePointServer
                     DatabaseName           = $webApp.DatabaseName
                     DatabaseServer         = $ConfigurationData.NonNodeData.SQLServer.ContentDatabaseServer
                     Url                    = $webApp.Url
+                    HostHeader             = $webApp.HostHeader
                     Port                   = [Uri]::new($webApp.Url).Port
                     PsDscRunAsCredential   = $SPSetupAccount
                     DependsOn              = "[SPManagedAccount]WebPoolManagedAccount"

--- a/Modules/SharePointDsc/Examples/Small Farm/SharePoint.psd1
+++ b/Modules/SharePointDsc/Examples/Small Farm/SharePoint.psd1
@@ -78,6 +78,7 @@
                     Name = "SharePoint Sites"
                     DatabaseName = "SP_Content_01"
                     Url = "http://sites.sharepoint.contoso.local"
+                    HostHeader = "sites.sharepoint.contoso.local"
                     Authentication = "NTLM"
                     Anonymous = $false
                     AppPool = "SharePoint Sites"


### PR DESCRIPTION
Added HostHeader parameters to Web application examples. This way multiple web applications can be created, without creating a blocker in IIS. Without this parameter, the website in IIS is created without host header and all other web applications won't be created due to an error.

- [X] Change details added to Unreleased section of changelog.md?
- [N/A] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [N/A] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [N/A] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/371)
<!-- Reviewable:end -->
