### PR TITLE
Prevented SPCreateFarm and SPJoinFarm from executing sets when in a farm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
  * Fixed the use of plural nouns in cmdlet names within the module
  * Removed dependency on Win32_Product from SPInstall
  * Added SPTrustedIdentityTokenIssuer, SPRemoteFarmTrust and SPSearchResultSource resources
- * Added HostHeader parameter in examples for Web Application, so subsequent web applications won't error out 
+ * Added HostHeader parameter in examples for Web Application, so subsequent web applications won't error out
+ * Prevented SPCreateFarm and SPJoinFarm from executing set methods where the local server is already a member of a farm 
 
 ### 1.1
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPCreateFarm/MSFT_SPCreateFarm.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPCreateFarm/MSFT_SPCreateFarm.psm1
@@ -4,40 +4,90 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $FarmAccount,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $true)]  [System.String] $AdminContentDatabaseName,
-        [parameter(Mandatory = $false)] [System.UInt32] $CentralAdministrationPort,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("NTLM","Kerberos")]$CentralAdministrationAuth,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $FarmAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $AdminContentDatabaseName,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $CentralAdministrationPort,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("NTLM","Kerberos")]
+        $CentralAdministrationAuth,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
 
     Write-Verbose -Message "Checking for local SP Farm"
 
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
-    $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+                                  -Arguments $PSBoundParameters `
+                                  -ScriptBlock {
         $params = $args[0]
 
-        try {
+        try 
+        {
             $spFarm = Get-SPFarm
-        } catch {
+        } 
+        catch 
+        {
             Write-Verbose -Message "Unable to detect local farm."
         }
         
         if ($null -eq $spFarm) { return $null }
 
-        $configDb = Get-SPDatabase | Where-Object { $_.Name -eq $spFarm.Name -and $_.Type -eq "Configuration Database" }
-        $centralAdminSite = Get-SPWebApplication -IncludeCentralAdministration | Where-Object { $_.IsAdministrationWebApplication -eq $true }
+        $configDb = Get-SPDatabase | Where-Object -FilterScript { 
+            $_.Name -eq $spFarm.Name -and $_.Type -eq "Configuration Database" 
+        }
+        $centralAdminSite = Get-SPWebApplication -IncludeCentralAdministration `
+                            | Where-Object -FilterScript { 
+            $_.IsAdministrationWebApplication -eq $true 
+        }
 
-        if ($params.FarmAccount.UserName -eq $spFarm.DefaultServiceAccount.Name) {
+        if ($params.FarmAccount.UserName -eq $spFarm.DefaultServiceAccount.Name) 
+        {
             $farmAccount = $params.FarmAccount
-        } else {
+        } 
+        else 
+        {
             $farmAccount = $spFarm.DefaultServiceAccount.Name
         }
 
@@ -61,25 +111,78 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $FarmAccount,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $true)]  [System.String] $AdminContentDatabaseName,
-        [parameter(Mandatory = $false)] [System.UInt32] $CentralAdministrationPort,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("NTLM","Kerberos")]$CentralAdministrationAuth,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $FarmAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $AdminContentDatabaseName,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $CentralAdministrationPort,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("NTLM","Kerberos")]
+        $CentralAdministrationAuth,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
     
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
-    if (-not $PSBoundParameters.ContainsKey("CentralAdministrationPort")) { $PSBoundParameters.Add("CentralAdministrationPort", 9999) }
-    if (-not $PSBoundParameters.ContainsKey("CentralAdministrationAuth")) { $PSBoundParameters.Add("CentralAdministrationAuth", "NTLM") }
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    if ([string]::IsNullOrEmpty($CurrentValues.FarmConfigDatabaseName) -eq $false) 
+    {
+        throw ("This server is already connected to a farm " + `
+               "($($CurrentValues.FarmConfigDatabaseName)). Please manually remove it " + `
+               "to apply this change.")
+    }
+
+    if (-not $PSBoundParameters.ContainsKey("CentralAdministrationPort")) 
+    { 
+        $PSBoundParameters.Add("CentralAdministrationPort", 9999) 
+    }
+    if (-not $PSBoundParameters.ContainsKey("CentralAdministrationAuth")) 
+    { 
+        $PSBoundParameters.Add("CentralAdministrationAuth", "NTLM") 
+    }
     
-    $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+    Invoke-SPDSCCommand -Credential $InstallAccount `
+                                  -Arguments $PSBoundParameters `
+                                  -ScriptBlock {
         $params = $args[0]
 
         $newFarmArgs = @{
@@ -91,21 +194,30 @@ function Set-TargetResource
             SkipRegisterAsDistributedCacheHost = $true
         }
         
-        switch((Get-SPDSCInstalledProductVersion).FileMajorPart) {
+        switch((Get-SPDSCInstalledProductVersion).FileMajorPart) 
+        {
             15 {
                 Write-Verbose -Message "Detected Version: SharePoint 2013"
             }
             16 {
-                if ($params.ContainsKey("ServerRole") -eq $true) {
-                    Write-Verbose -Message "Detected Version: SharePoint 2016 - configuring server as $($params.ServerRole)"
+                if ($params.ContainsKey("ServerRole") -eq $true) 
+                {
+                    Write-Verbose -Message ("Detected Version: SharePoint 2016 - " + `
+                                            "configuring server as $($params.ServerRole)")
                     $newFarmArgs.Add("LocalServerRole", $params.ServerRole)
-                } else {
-                    Write-Verbose -Message "Detected Version: SharePoint 2016 - no server role provided, configuring server without a specific role"
+                } 
+                else 
+                {
+                    Write-Verbose -Message ("Detected Version: SharePoint 2016 - no " + `
+                                            "server role provided, configuring server " + `
+                                            "without a specific role")
                     $newFarmArgs.Add("ServerRoleOptional", $true)
                 }
             }
             Default {
-                throw [Exception] "An unknown version of SharePoint (Major version $_) was detected. Only versions 15 (SharePoint 2013) or 16 (SharePoint 2016) are supported."
+                throw [Exception] ("An unknown version of SharePoint (Major version $_) was " + `
+                                   "detected. Only versions 15 (SharePoint 2013) or 16 " + `
+                                   "(SharePoint 2016) are supported.")
             }
         }
 
@@ -116,7 +228,7 @@ function Set-TargetResource
         Install-SPFeature -AllExistingFeatures -Force 
         New-SPCentralAdministration -Port $params.CentralAdministrationPort -WindowsAuthProvider $params.CentralAdministrationAuth
         Install-SPApplicationContent
-    }
+    } | Out-Null
 }
 
 function Test-TargetResource
@@ -125,25 +237,64 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $FarmAccount,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $true)]  [System.String] $AdminContentDatabaseName,
-        [parameter(Mandatory = $false)] [System.UInt32] $CentralAdministrationPort,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("NTLM","Kerberos")]$CentralAdministrationAuth,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $FarmAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $AdminContentDatabaseName,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $CentralAdministrationPort,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("NTLM","Kerberos")]
+        $CentralAdministrationAuth,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
 
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     Write-Verbose "Checking for local farm presence"
     if ($null -eq $CurrentValues) { return $false }
-    return Test-SPDscParameterState -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("FarmConfigDatabaseName")
+    return Test-SPDscParameterState -CurrentValues $CurrentValues `
+                                    -DesiredValues $PSBoundParameters `
+                                    -ValuesToCheck @("FarmConfigDatabaseName")
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPJoinFarm/MSFT_SPJoinFarm.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPJoinFarm/MSFT_SPJoinFarm.psm1
@@ -4,32 +4,65 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
 
     Write-Verbose -Message "Checking for local SP Farm"
 
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
-    $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+                                  -Arguments $PSBoundParameters `
+                                  -ScriptBlock {
         $params = $args[0]
         
-
-        try {
+        try 
+        {
             $spFarm = Get-SPFarm -ErrorAction SilentlyContinue
-        } catch {
+        } 
+        catch 
+        {
             Write-Verbose -Message "Unable to detect local farm."
         }
         
-        if ($null -eq $spFarm) {return @{ }}
+        if ($null -eq $spFarm) 
+        {
+            return @{ }
+        }
 
-        $configDb = Get-SPDatabase | Where-Object { $_.Name -eq $spFarm.Name -and $_.Type -eq "Configuration Database" }
+        $configDb = Get-SPDatabase | Where-Object -FilterScript { 
+            $_.Name -eq $spFarm.Name -and $_.Type -eq "Configuration Database" 
+        }
 
         return @{
             FarmConfigDatabaseName = $spFarm.Name
@@ -47,61 +80,112 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
 
     Write-Verbose -Message "Joining existing farm configuration database"
 
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
-    Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    if ([string]::IsNullOrEmpty($CurrentValues.FarmConfigDatabaseName) -eq $false) 
+    {
+        throw ("This server is already connected to a farm " + `
+               "($($CurrentValues.FarmConfigDatabaseName)). Please manually remove it " + `
+               "to apply this change.")
+    }
+
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+                        -Arguments $PSBoundParameters `
+                        -ScriptBlock {
         $params = $args[0]
         
-
-        $joinFarmArgs = @{
-            DatabaseServer = $params.DatabaseServer
-            DatabaseName = $params.FarmConfigDatabaseName
-            Passphrase = $params.Passphrase.password
-            SkipRegisterAsDistributedCacheHost = $true
-        }
-        
-        switch((Get-SPDSCInstalledProductVersion).FileMajorPart) {
-            15 {
-                Write-Verbose -Message "Detected Version: SharePoint 2013"
+        try {
+            $joinFarmArgs = @{
+                DatabaseServer = $params.DatabaseServer
+                DatabaseName = $params.FarmConfigDatabaseName
+                Passphrase = $params.Passphrase.password
+                SkipRegisterAsDistributedCacheHost = $true
             }
-            16 {
-                if ($params.ContainsKey("ServerRole") -eq $true) {
-                    Write-Verbose -Message "Detected Version: SharePoint 2016 - configuring server as $($params.ServerRole)"
-                    $joinFarmArgs.Add("LocalServerRole", $params.ServerRole)
-                } else {
-                    Write-Verbose -Message "Detected Version: SharePoint 2016 - no server role provided, configuring server without a specific role"
+            
+            switch((Get-SPDSCInstalledProductVersion).FileMajorPart) {
+                15 {
+                    Write-Verbose -Message "Detected Version: SharePoint 2013"
+                }
+                16 {
+                    if ($params.ContainsKey("ServerRole") -eq $true) {
+                        Write-Verbose -Message ("Detected Version: SharePoint 2016 - " + `
+                                                "configuring server as $($params.ServerRole)")
+                        $joinFarmArgs.Add("LocalServerRole", $params.ServerRole)
+                    } else {
+                        Write-Verbose -Message ("Detected Version: SharePoint 2016 - no server " + `
+                                                "role provided, configuring server without a " + `
+                                                "specific role")
+                    }
+                }
+                Default {
+                    throw [Exception] ("An unknown version of SharePoint (Major version $_) " + `
+                                       "was detected. Only versions 15 (SharePoint 2013) or " + `
+                                       "16 (SharePoint 2016) are supported.")
                 }
             }
-            Default {
-                throw [Exception] "An unknown version of SharePoint (Major version $_) was detected. Only versions 15 (SharePoint 2013) or 16 (SharePoint 2016) are supported."
-            }
-        }
 
-        Connect-SPConfigurationDatabase @joinFarmArgs
-        Install-SPHelpCollection -All
-        Initialize-SPResourceSecurity
-        Install-SPService
-        Install-SPFeature -AllExistingFeatures -Force 
-        Install-SPApplicationContent
+            Connect-SPConfigurationDatabase @joinFarmArgs
+            Install-SPHelpCollection -All
+            Initialize-SPResourceSecurity
+            Install-SPService
+            Install-SPFeature -AllExistingFeatures -Force 
+            Install-SPApplicationContent    
+        }
+        catch [System.Exception] {
+            return $_
+        }
+    }
+
+    if ($null -ne $result)
+    {
+        Write-Verbose -Message "An error occured joining the farm"
+        throw $_
     }
 
     Write-Verbose -Message "Starting timer service"
     Start-Service -Name sptimerv4
 
-    Write-Verbose -Message "Pausing for 5 minutes to allow the timer service to fully provision the server"
+    Write-Verbose -Message ("Pausing for 5 minutes to allow the timer service to " + `
+                            "fully provision the server")
     Start-Sleep -Seconds 300
-    Write-Verbose -Message "Join farm complete. Restarting computer to allow configuration to continue"
+    Write-Verbose -Message ("Join farm complete. Restarting computer to allow " + `
+                            "configuration to continue")
 
     $global:DSCMachineStatus = 1
 }
@@ -113,20 +197,46 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $FarmConfigDatabaseName,
-        [parameter(Mandatory = $true)]  [System.String] $DatabaseServer,
-        [parameter(Mandatory = $true)]  [System.Management.Automation.PSCredential] $Passphrase,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] [ValidateSet("Application","Custom","DistributedCache","Search","SingleServer","SingleServerFarm","SpecialLoad","WebFrontEnd")] $ServerRole
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $FarmConfigDatabaseName,
+
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $DatabaseServer,
+
+        [parameter(Mandatory = $true)]  
+        [System.Management.Automation.PSCredential] 
+        $Passphrase,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $false)] 
+        [System.String] 
+        [ValidateSet("Application",
+                     "Custom",
+                     "DistributedCache",
+                     "Search",
+                     "SingleServer",
+                     "SingleServerFarm",
+                     "SpecialLoad",
+                     "WebFrontEnd")] 
+        $ServerRole
     )
 
-    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) {
+    if (($PSBoundParameters.ContainsKey("ServerRole") -eq $true) `
+        -and (Get-SPDSCInstalledProductVersion).FileMajorPart -ne 16) 
+    {
         throw [Exception] "Server role is only supported in SharePoint 2016."
     }
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     Write-Verbose "Testing for local farm presence"
-    return Test-SPDscParameterState -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters -ValuesToCheck @("FarmConfigDatabaseName") 
+    return Test-SPDscParameterState -CurrentValues $CurrentValues `
+                                    -DesiredValues $PSBoundParameters `
+                                    -ValuesToCheck @("FarmConfigDatabaseName") 
 }
 
 

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPJoinFarm.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPJoinFarm.Tests.ps1
@@ -100,7 +100,7 @@ Describe "SPJoinFarm - SharePoint Build $((Get-Item $SharePointCmdletModule).Dir
             }
         }
 
-        Context "a farm exists locally" {
+        Context "a farm exists locally and is the correct farm" {
             Mock Get-SPFarm { return @{ 
                 DefaultServiceAccount = @{ Name = $testParams.FarmAccount.UserName }
                 Name = $testParams.FarmConfigDatabaseName
@@ -117,6 +117,22 @@ Describe "SPJoinFarm - SharePoint Build $((Get-Item $SharePointCmdletModule).Dir
 
             It "returns true from the test method" {
                 Test-TargetResource @testParams | Should Be $true
+            }
+        }
+
+        Context "a farm exists locally and is not the correct farm" {
+            Mock Get-SPFarm { return @{ 
+                DefaultServiceAccount = @{ Name = $testParams.FarmAccount.UserName }
+                Name = "WrongDBName"
+            }}
+            Mock Get-SPDatabase { return @(@{ 
+                Name = "WrongDBName"
+                Type = "Configuration Database"
+                Server = @{ Name = $testParams.DatabaseServer }
+            })} 
+
+            It "throws an error in the set method" {
+                { Set-TargetResource @testParams } | Should throw
             }
         }
     }    

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPPasswordChangeSettings.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPPasswordChangeSettings.Tests.ps1
@@ -33,7 +33,7 @@ Describe "SPPasswordChangeSettings - SharePoint Build $((Get-Item $SharePointCmd
             Mock Get-SPFarm { return $null }
 
             It "returns null from the get method" {
-                Get-TargetResource @testParams | Should Throw 
+                { Get-TargetResource @testParams } | Should Throw 
             }
 
             It "returns false from the test method" {

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPPasswordChangeSettings.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPPasswordChangeSettings.Tests.ps1
@@ -33,7 +33,7 @@ Describe "SPPasswordChangeSettings - SharePoint Build $((Get-Item $SharePointCmd
             Mock Get-SPFarm { return $null }
 
             It "returns null from the get method" {
-                { Get-TargetResource @testParams } | Should Throw 
+                Get-TargetResource @testParams | Should BeNullOrEmpty 
             }
 
             It "returns false from the test method" {


### PR DESCRIPTION
Fixes #375 - we do a check in the set methods now to ensure we aren't trying to create or join where an existing farm is there, warning the user that they must manually remove it first if the config is to be applied.

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/376)
<!-- Reviewable:end -->
