### PR TITLE
Fixed quote template test logic for equal warnings and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Added ProxyName parameter to all service application resources
  * Changed SPServiceInstance to look for object type names instead of the display name to ensure consistency with language packs
  * Fixed typos in documentation for InstallAccount parameter on most resources
+ * Fixed a bug where SPQuotaTemplate would not allow warning and limit values to be equal
 
 ### 1.2
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPQuotaTemplate/MSFT_SPQuotaTemplate.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPQuotaTemplate/MSFT_SPQuotaTemplate.psm1
@@ -4,49 +4,91 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String]  $Name,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageMaxInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageWarningInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $MaximumUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [System.UInt32]  $WarningUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+        [parameter(Mandatory = $true)]  
+        [System.String]  
+        $Name,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageMaxInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageWarningInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $MaximumUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $WarningUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount
     )
     
     Write-Verbose -Message "Getting Quota Template settings"
-    if ($StorageMaxInMB -lt $StorageWarningInMB) {
+    if ($StorageMaxInMB -lt $StorageWarningInMB) 
+    {
         Throw "StorageMaxInMB must be larger than StorageWarningInMB."
     }
 
-    if ($MaximumUsagePointsSolutions -lt $WarningUsagePointsSolutions) {
+    if ($MaximumUsagePointsSolutions -lt $WarningUsagePointsSolutions) 
+    {
         Throw "MaximumUsagePointsSolutions must be larger than WarningUsagePointsSolutions."
     }
 
-    $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+                                  -Arguments $PSBoundParameters `
+                                  -ScriptBlock {
         $params = $args[0]
         
-        try {
+        try 
+        {
             $spFarm = Get-SPFarm
-        } catch {
-            Write-Verbose -Verbose "No local SharePoint farm was detected. Quota template settings will not be applied"
-            return $null
+        } 
+        catch 
+        {
+            Write-Verbose -Message ("No local SharePoint farm was detected. Quota " + `
+                                    "template settings will not be applied")
+            return @{
+                Name = $params.Name
+                StorageMaxInMB = 0
+                StorageWarningInMB = 0 
+                MaximumUsagePointsSolutions = 0
+                WarningUsagePointsSolutions = 0
+                Ensure = "Absent"
+                InstallAccount = $params.InstallAccount
+            }
         }
 
         # Get a reference to the Administration WebService
         $admService = Get-SPDSCContentService
 
         $template = $admService.QuotaTemplates[$params.Name]
-        if ($null -eq $template) { 
+        if ($null -eq $template) 
+        { 
             return @{
                 Name = $params.Name
                 Ensure = "Absent"
                 InstallAccount = $params.InstallAccount
             }
-        } else {
+        } 
+        else 
+        {
             return @{
                 Name = $params.Name
-                StorageMaxInMB = ($template.StorageMaximumLevel / 1MB) # Convert from bytes to megabytes
-                StorageWarningInMB = ($template.StorageWarningLevel / 1MB) # Convert from bytes to megabytes
+                # Convert from bytes to megabytes
+                StorageMaxInMB = ($template.StorageMaximumLevel / 1MB) 
+                # Convert from bytes to megabytes
+                StorageWarningInMB = ($template.StorageWarningLevel / 1MB) 
                 MaximumUsagePointsSolutions = $template.UserCodeMaximumLevel
                 WarningUsagePointsSolutions = $template.UserCodeWarningLevel
                 Ensure = "Present"
@@ -63,35 +105,65 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String]  $Name,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageMaxInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageWarningInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $MaximumUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [System.UInt32]  $WarningUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+        [parameter(Mandatory = $true)]  
+        [System.String]  
+        $Name,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageMaxInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageWarningInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $MaximumUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $WarningUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount
     )
 
     Write-Verbose -Message "Setting quota template settings"
 
-    if ($StorageMaxInMB -lt $StorageWarningInMB) {
+    if ($StorageMaxInMB -lt $StorageWarningInMB) 
+    {
         Throw "StorageMaxInMB must be larger than StorageWarningInMB."
     }
 
-    if ($MaximumUsagePointsSolutions -lt $WarningUsagePointsSolutions) {
+    if ($MaximumUsagePointsSolutions -lt $WarningUsagePointsSolutions) 
+    {
         Throw "MaximumUsagePointsSolutions must be larger than WarningUsagePointsSolutions."
     }
 
-    switch ($Ensure) {
+    switch ($Ensure) 
+    {
         "Present" {
             Write-Verbose "Ensure is set to Present - Add or update template"
-            Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+            Invoke-SPDSCCommand -Credential $InstallAccount `
+                                -Arguments $PSBoundParameters `
+                                -ScriptBlock {
                 $params = $args[0]
         
-                try {
+                try 
+                {
                     $spFarm = Get-SPFarm
-                } catch {
-                    throw "No local SharePoint farm was detected. Antivirus settings will not be applied"
+                } 
+                catch 
+                {
+                    throw ("No local SharePoint farm was detected. Quota " + `
+                           "template settings will not be applied")
                     return
                 }
 
@@ -101,22 +173,49 @@ function Set-TargetResource
 
                 $template = $admService.QuotaTemplates[$params.Name]
 
-                if ($null -eq $template) { 
+                if ($null -eq $template) 
+                { 
                     #Template does not exist, create new template
                     $newTemplate = New-Object Microsoft.SharePoint.Administration.SPQuotaTemplate
                     $newTemplate.Name = $params.Name
-                    if ($params.ContainsKey("StorageMaxInMB")) { $newTemplate.StorageMaximumLevel = ($params.StorageMaxInMB * 1MB) } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("StorageWarningInMB")) { $newTemplate.StorageWarningLevel = ($params.StorageWarningInMB * 1MB) } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("MaximumUsagePointsSolutions")) { $newTemplate.UserCodeMaximumLevel = $params.MaximumUsagePointsSolutions } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("WarningUsagePointsSolutions")) { $newTemplate.UserCodeWarningLevel = $params.WarningUsagePointsSolutions } # Convert from megabytes to bytes
+                    if ($params.ContainsKey("StorageMaxInMB")) 
+                    { 
+                        $newTemplate.StorageMaximumLevel = ($params.StorageMaxInMB * 1MB) 
+                    }
+                    if ($params.ContainsKey("StorageWarningInMB")) 
+                    { 
+                        $newTemplate.StorageWarningLevel = ($params.StorageWarningInMB * 1MB) 
+                    } 
+                    if ($params.ContainsKey("MaximumUsagePointsSolutions")) 
+                    { 
+                        $newTemplate.UserCodeMaximumLevel = $params.MaximumUsagePointsSolutions 
+                    } 
+                    if ($params.ContainsKey("WarningUsagePointsSolutions")) 
+                    { 
+                        $newTemplate.UserCodeWarningLevel = $params.WarningUsagePointsSolutions 
+                    } 
                     $admService.QuotaTemplates.Add($newTemplate)
                     $admService.Update()
-                } else {
+                } 
+                else 
+                {
                     #Template exists, update settings
-                    if ($params.ContainsKey("StorageMaxInMB")) { $template.StorageMaximumLevel = ($params.StorageMaxInMB * 1MB) } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("StorageWarningInMB")) { $template.StorageWarningLevel = ($params.StorageWarningInMB * 1MB) } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("MaximumUsagePointsSolutions")) { $template.UserCodeMaximumLevel = $params.MaximumUsagePointsSolutions } # Convert from megabytes to bytes
-                    if ($params.ContainsKey("WarningUsagePointsSolutions")) { $template.UserCodeWarningLevel = $params.WarningUsagePointsSolutions } # Convert from megabytes to bytes
+                    if ($params.ContainsKey("StorageMaxInMB")) 
+                    { 
+                        $template.StorageMaximumLevel = ($params.StorageMaxInMB * 1MB) 
+                    } 
+                    if ($params.ContainsKey("StorageWarningInMB")) 
+                    { 
+                        $template.StorageWarningLevel = ($params.StorageWarningInMB * 1MB) 
+                    } 
+                    if ($params.ContainsKey("MaximumUsagePointsSolutions")) 
+                    { 
+                        $template.UserCodeMaximumLevel = $params.MaximumUsagePointsSolutions 
+                    } 
+                    if ($params.ContainsKey("WarningUsagePointsSolutions")) 
+                    { 
+                        $template.UserCodeWarningLevel = $params.WarningUsagePointsSolutions 
+                    }
                     $admService.Update()
                 }
             }
@@ -124,17 +223,29 @@ function Set-TargetResource
         "Absent" {
             Write-Verbose "Ensure is set to Absent - Removing template"
 
-            if ($StorageMaxInMB -or $StorageWarningInMB -or $MaximumUsagePointsSolutions -or $WarningUsagePointsSolutions) {
-                Throw "Do not use StorageMaxInMB, StorageWarningInMB, MaximumUsagePointsSolutions or WarningUsagePointsSolutions when Ensure is specified as Absent"
+            if ($StorageMaxInMB `
+                -or $StorageWarningInMB `
+                -or $MaximumUsagePointsSolutions `
+                -or $WarningUsagePointsSolutions) 
+            {
+                Throw ("Do not use StorageMaxInMB, StorageWarningInMB, " + `
+                       "MaximumUsagePointsSolutions or WarningUsagePointsSolutions " + `
+                       "when Ensure is specified as Absent")
             }
 
-            Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
+            Invoke-SPDSCCommand -Credential $InstallAccount `
+                                -Arguments $PSBoundParameters `
+                                -ScriptBlock {
                 $params = $args[0]
         
-                try {
+                try 
+                {
                     $spFarm = Get-SPFarm
-                } catch {
-                    Write-Verbose -Verbose "No local SharePoint farm was detected. Quota template settings will not be applied"
+                } 
+                catch 
+                {
+                    Write-Verbose -Message ("No local SharePoint farm was detected. Quota " + `
+                                            "template settings will not be applied")
                     return
                 }
 
@@ -142,7 +253,8 @@ function Set-TargetResource
                 # Get a reference to the Administration WebService
                 $admService = Get-SPDSCContentService
 
-                # Delete template, function does not throw an error when the template does not exist. So safe to call without error handling.
+                # Delete template, function does not throw an error when the template does not 
+                # exist. So safe to call without error handling.
                 $admService.QuotaTemplates.Delete($params.Name)
             }
         }
@@ -156,40 +268,77 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String]  $Name,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageMaxInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $StorageWarningInMB,
-        [parameter(Mandatory = $false)] [System.UInt32]  $MaximumUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [System.UInt32]  $WarningUsagePointsSolutions,
-        [parameter(Mandatory = $false)] [ValidateSet("Present","Absent")] [System.String] $Ensure = "Present",
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount
+        [parameter(Mandatory = $true)]  
+        [System.String]  
+        $Name,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageMaxInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $StorageWarningInMB,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32]  
+        $MaximumUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [System.UInt32] 
+        $WarningUsagePointsSolutions,
+
+        [parameter(Mandatory = $false)] 
+        [ValidateSet("Present","Absent")] 
+        [System.String] 
+        $Ensure = "Present",
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount
     )
 
     Write-Verbose -Message "Testing quota template settings"
-    if ($StorageMaxInMB -lt $StorageWarningInMB) {
-        Throw "StorageMaxInMB must be larger than StorageWarningInMB."
+    if ($StorageMaxInMB -le $StorageWarningInMB) 
+    {
+        Throw "StorageMaxInMB must be equal to or larger than StorageWarningInMB."
     }
 
-    if ($MaximumUsagePointsSolutions -lt $WarningUsagePointsSolutions) {
-        Throw "MaximumUsagePointsSolutions must be larger than WarningUsagePointsSolutions."
+    if ($MaximumUsagePointsSolutions -le $WarningUsagePointsSolutions) 
+    {
+        Throw ("MaximumUsagePointsSolutions must be equal to or larger than " + `
+               "WarningUsagePointsSolutions.")
     }
 
-    switch ($Ensure) {
+    switch ($Ensure) 
+    {
         "Present" {
             $CurrentValues = Get-TargetResource @PSBoundParameters
-            if (($CurrentValues.Ensure -eq "Absent") -or ($null -eq $CurrentValues)) { return $false }
+            if ($CurrentValues.Ensure -eq "Absent")
+            { 
+                return $false 
+            }
             return Test-SPDscParameterState -CurrentValues $CurrentValues -DesiredValues $PSBoundParameters
         }
         "Absent" {
-            if ($StorageMaxInMB -or $StorageWarningInMB -or $MaximumUsagePointsSolutions -or $WarningUsagePointsSolutions) {
-                Throw "Do not use StorageMaxInMB, StorageWarningInMB, MaximumUsagePointsSolutions or WarningUsagePointsSolutions when Ensure is specified as Absent"
+            if ($StorageMaxInMB `
+                -or $StorageWarningInMB `
+                -or $MaximumUsagePointsSolutions `
+                -or $WarningUsagePointsSolutions) 
+            {
+                Throw ("Do not use StorageMaxInMB, StorageWarningInMB, " + `
+                       "MaximumUsagePointsSolutions or WarningUsagePointsSolutions " + `
+                       "when Ensure is specified as Absent")
             }
 
             $CurrentValues = Get-TargetResource @PSBoundParameters
-            if (($CurrentValues.Ensure -eq "Present") -or ($null -eq $CurrentValues)) { 
+            if ($CurrentValues.Ensure -eq "Present") 
+            { 
                 # Error occured in Get method or template exists, which is not supposed to be. Return false
                 return $false
-            } else { 
+            } 
+            else 
+            { 
                 # Template does not exists, which is supposed to be. Return true
                 return $true
             } 

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPQuotaTemplate.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPQuotaTemplate.Tests.ps1
@@ -37,7 +37,7 @@ Describe "SPQuotaTemplate - SharePoint Build $((Get-Item $SharePointCmdletModule
             Mock Get-SPFarm { throw "Unable to detect local farm" }
 
             It "return null from the get method" {
-                Get-TargetResource @testParams | Should Be $null
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
             }
 
             It "returns false from the test method" {


### PR DESCRIPTION
Fixing a scenario where the warning and limits are both 0, so really changing the -lt to a -le in the test method. Also brought it in line with the style guidelines and removed the $null return option from the get method.

- [X] Change details added to Unreleased section of changelog.md?
- [n/a] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [n/a] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/388)
<!-- Reviewable:end -->
