### PR TITLE
Improved and fixed multiple issues with resource SPTrustedIdentityTokenIssuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
  * Changed SPServiceInstance to look for object type names instead of the display name to ensure consistency with language packs
  * Fixed typos in documentation for InstallAccount parameter on most resources
  * Fixed a bug where SPQuotaTemplate would not allow warning and limit values to be equal
+ * Changed SPTrustedIdentityTokenIssuer to use a JSON array for ClaimsMappings to simplify the syntax
+ * Changed SPTrustedIdentityTokenIssuer to throw an exception if certificate specified has a private key, since SharePoint doesn't accept it
+ * Fixed issue with SPTrustedIdentityTokenIssuer to stop if cmdlet New-SPTrustedIdentityTokenIssuer fails to create the SPTrustedIdentityTokenIssuer and returns null
+ * Fixed issue with SPTrustedIdentityTokenIssuer to correctly get parameters ClaimProviderName and ProviderSignOutUri
+ * Fixed issue with SPTrustedIdentityTokenIssuer to effectively remove the SPTrustedAuthenticationProvider from all zones before deleting the SPTrustedIdentityTokenIssuer
+
 
 ### 1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
  * Changed SPServiceInstance to look for object type names instead of the display name to ensure consistency with language packs
  * Fixed typos in documentation for InstallAccount parameter on most resources
  * Fixed a bug where SPQuotaTemplate would not allow warning and limit values to be equal
- * Changed SPTrustedIdentityTokenIssuer to use a JSON array for ClaimsMappings to simplify the syntax
+ * Changed parameter ClaimsMappings in SPTrustedIdentityTokenIssuer to consume a JSON array, to allow an easier syntax
  * Changed SPTrustedIdentityTokenIssuer to throw an exception if certificate specified has a private key, since SharePoint doesn't accept it
- * Fixed issue with SPTrustedIdentityTokenIssuer to stop if cmdlet New-SPTrustedIdentityTokenIssuer fails to create the SPTrustedIdentityTokenIssuer and returns null
+ * Fixed issue with SPTrustedIdentityTokenIssuer to stop if cmdlet New-SPTrustedIdentityTokenIssuer returns null
  * Fixed issue with SPTrustedIdentityTokenIssuer to correctly get parameters ClaimProviderName and ProviderSignOutUri
  * Fixed issue with SPTrustedIdentityTokenIssuer to effectively remove the SPTrustedAuthenticationProvider from all zones before deleting the SPTrustedIdentityTokenIssuer
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -92,7 +92,7 @@ function Set-TargetResource
     {
         if ($CurrentValues.Ensure -eq "Absent")
         {
-            Write-Verbose "Create SPTrustedIdentityTokenIssuer '$Name'..."
+            Write-Verbose "Creating SPTrustedIdentityTokenIssuer '$Name'..."
             $result = Invoke-SPDSCCommand -Credential $InstallAccount -Arguments $PSBoundParameters -ScriptBlock {
                 $params = $args[0]
 
@@ -108,10 +108,10 @@ function Set-TargetResource
                 }
                 
                 $claimsMappingsArray = @()
-                $MappingsList = $params.ClaimsMappings| ConvertFrom-Json
+                $MappingsList = $params.ClaimsMappings| ConvertFrom-Json -ErrorAction SilentlyContinue
                 $MappingsList.Mappings| Foreach-Object {
                     # Even if $MappingsList.Mappings array does not exist, Foreach iterates once with a null object, so test it before any processing
-                    if ($null -eq $_)
+                    if ($null -eq $_ -or $null -eq $_.Name -or $null -eq $_.IncomingClaimType)
                     {
                         return
                     }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.psm1
@@ -108,10 +108,12 @@ function Set-TargetResource
                     $runParams = @{}
                     $runParams.Add("IncomingClaimTypeDisplayName", $_.Name)
                     $runParams.Add("IncomingClaimType", $_.IncomingClaimType)
-                    if ($_.LocalClaimType -eq $null) {
+                    if ($_.LocalClaimType -eq $null) 
+                    {
                         $runParams.Add("LocalClaimType", $_.IncomingClaimType)
                     }
-                    else {
+                    else 
+                    {
                         $runParams.Add("LocalClaimType", $_.LocalClaimType)
                     }
                     $claimsMappingsArray = $claimsMappingsArray + (New-SPClaimTypeMapping @runParams)

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
@@ -4,7 +4,7 @@ class MSFT_SPClaimTypeMapping
 {
     [Key, Description("Display name of the incoming claim type")] String Name;
     [Required, Description("URI of the incoming claim type")] String IncomingClaimType;
-    [Write, Description("URI of the local claim type; not required if same as IncomingClaimType")] String LocalClaimType;
+    [Write, Description("URI of the local claim type, not required if same as IncomingClaimType")] String LocalClaimType;
 };
 
 
@@ -16,11 +16,11 @@ class MSFT_SPTrustedIdentityTokenIssuer : OMI_BaseResource
     [Required, Description("Default Realm that is passed to identity provider")] String Realm;
     [Required, Description("URL of the identity provider where user is redirected to for authentication")] String SignInUrl;
     [Required, Description("Identity claim type that uniquely identifies the user")] String IdentifierClaim;
-    [Required, EmbeddedInstance("MSFT_SPClaimTypeMapping"), Description("Array of MSFT_SPClaimTypeMapping to use with cmdlet New-SPClaimTypeMapping")] String ClaimsMappings[];
+    [Required, Description("Array of MSFT_SPClaimTypeMapping to use with cmdlet New-SPClaimTypeMapping"), EmbeddedInstance("MSFT_SPClaimTypeMapping")] String ClaimsMappings[];
     [Required, Description("Thumbprint of the signing certificate to use with this SPTrustedIdentityTokenIssuer. It must match the thumbprint of a certificate located in store LocalMachine\\My")] String SigningCertificateThumbPrint;
     [Write, Description("Name of a claims provider to set with this SPTrustedIdentityTokenIssuer")] String ClaimProviderName;
     [Write, Description("Sign-out URL")] String ProviderSignOutUri;
     [Write, Description("Present if the SPTrustedIdentityTokenIssuer should be created, or Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Write, EmbeddedInstance("MSFT_Credential"), Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5")] String InstallAccount;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
@@ -6,9 +6,9 @@ class MSFT_SPTrustedIdentityTokenIssuer : OMI_BaseResource
     [Required, Description("Default Realm that is passed to identity provider")] String Realm;
     [Required, Description("URL of the identity provider where user is redirected to for authentication")] String SignInUrl;
     [Required, Description("Identity claim type that uniquely identifies the user")] String IdentifierClaim;
-    [Required, Description("List of HashTables that contain parameters for New-SPClaimTypeMapping cmdlet"), EmbeddedInstance("MSFT_KeyValuePair")] String ClaimsMappings[];
+    [Required, Description("JSON array that hosts parameters for cmdlet New-SPClaimTypeMapping")] String ClaimsMappings;
     [Required, Description("Thumbprint of the signing certificate to use with this SPTrustedIdentityTokenIssuer. It must match the thumbprint of a certificate located in store LocalMachine\\My")] String SigningCertificateThumbPrint;
-    [Write, Description("Name of a claims provider to set with this SPTrustedIdentityTokenIssuer.")] String ClaimProviderName;
+    [Write, Description("Name of a claims provider to set with this SPTrustedIdentityTokenIssuer")] String ClaimProviderName;
     [Write, Description("Sign-out URL")] String ProviderSignOutUri;
     [Write, Description("Present if the SPTrustedIdentityTokenIssuer should be created, or Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/MSFT_SPTrustedIdentityTokenIssuer.schema.mof
@@ -1,3 +1,13 @@
+
+[ClassVersion("1.0.0.0")]
+class MSFT_SPClaimTypeMapping
+{
+    [Key, Description("Display name of the incoming claim type")] String Name;
+    [Required, Description("URI of the incoming claim type")] String IncomingClaimType;
+    [Write, Description("URI of the local claim type; not required if same as IncomingClaimType")] String LocalClaimType;
+};
+
+
 [ClassVersion("1.0.0.0"), FriendlyName("SPTrustedIdentityTokenIssuer")]
 class MSFT_SPTrustedIdentityTokenIssuer : OMI_BaseResource
 {
@@ -6,10 +16,11 @@ class MSFT_SPTrustedIdentityTokenIssuer : OMI_BaseResource
     [Required, Description("Default Realm that is passed to identity provider")] String Realm;
     [Required, Description("URL of the identity provider where user is redirected to for authentication")] String SignInUrl;
     [Required, Description("Identity claim type that uniquely identifies the user")] String IdentifierClaim;
-    [Required, Description("JSON array that hosts parameters for cmdlet New-SPClaimTypeMapping")] String ClaimsMappings;
+    [Required, EmbeddedInstance("MSFT_SPClaimTypeMapping"), Description("Array of MSFT_SPClaimTypeMapping to use with cmdlet New-SPClaimTypeMapping")] String ClaimsMappings[];
     [Required, Description("Thumbprint of the signing certificate to use with this SPTrustedIdentityTokenIssuer. It must match the thumbprint of a certificate located in store LocalMachine\\My")] String SigningCertificateThumbPrint;
     [Write, Description("Name of a claims provider to set with this SPTrustedIdentityTokenIssuer")] String ClaimProviderName;
     [Write, Description("Sign-out URL")] String ProviderSignOutUri;
     [Write, Description("Present if the SPTrustedIdentityTokenIssuer should be created, or Absent if it should be removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+    [Write, EmbeddedInstance("MSFT_Credential"), Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5")] String InstallAccount;
 };
+

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
@@ -4,14 +4,15 @@ This resource is used to create or remove SPTrustedIdentityTokenIssuer in a Shar
 farm. 
 
 The SigningCertificateThumbPrint must match the thumbprint of a certificate in the 
-store LocalMachine\My of the server that will run this resource. Once the 
-SPTrustedIdentityTokenIssuer is successfully created, the certificate can be safely 
-deleted from this store as it won't be needed by SharePoint.
+store LocalMachine\My of the server that will run this resource. 
+Note that the private key of the certificate must not be available in the certiificate
+store because SharePoint does not accept it.
+Once the SPTrustedIdentityTokenIssuer is successfully created, the certificate can be 
+safely deleted from the certificate store as it won't be needed by SharePoint.
 
-ClaimsMappings is a JSON array that hosts parameters for cmdlet New-SPClaimTypeMapping.
-Array name is Mappings that contains an array of key/value pairs. Each entry requires
-keys Name and IncomingClaimType. Key LocalClaimType is not required if its value is 
-identical to IncomingClaimType.
+ClaimsMappings is an array of MSFT_SPClaimTypeMapping to use with cmdlet New-SPClaimTypeMapping.
+Each MSFT_SPClaimTypeMapping requires properties Name and IncomingClaimType. 
+Property LocalClaimType is not required if its value is identical to IncomingClaimType.
 
 The IdentifierClaim property must match an IncomingClaimType element in ClaimsMappings array.
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTrustedIdentityTokenIssuer/readme.md
@@ -8,9 +8,10 @@ store LocalMachine\My of the server that will run this resource. Once the
 SPTrustedIdentityTokenIssuer is successfully created, the certificate can be safely 
 deleted from this store as it won't be needed by SharePoint.
 
-ClaimsMappings is an array of HashTables that host parameters for New-SPClaimTypeMapping 
-cmdlet. Required properties are Name and IncomingClaimType. It's not necessary to specify 
-property LocalClaimType if it's identical to IncomingClaimType.
+ClaimsMappings is a JSON array that hosts parameters for cmdlet New-SPClaimTypeMapping.
+Array name is Mappings that contains an array of key/value pairs. Each entry requires
+keys Name and IncomingClaimType. Key LocalClaimType is not required if its value is 
+identical to IncomingClaimType.
 
 The IdentifierClaim property must match an IncomingClaimType element in ClaimsMappings array.
 

--- a/Modules/SharePointDsc/Examples/Resources/SPTrustedIdentityTokenIssuer/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPTrustedIdentityTokenIssuer/1-Example.ps1
@@ -20,7 +20,7 @@
                 Realm                        = "https://sharepoint.contoso.com"
                 SignInUrl                    = "https://adfs.contoso.com/adfs/ls/"
                 IdentifierClaim              = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-                ClaimsMappings               = @( @{Name = "Email"; IncomingClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"}, @{Name = "Account name"; IncomingClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"; LocalClaimType = "http://schemas.xmlsoap.org/customSPGroupClaimType"} )
+                ClaimsMappings               = "{'Mappings': [{'Name': 'Email', 'IncomingClaimType': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'}, {'Name': 'Role', 'IncomingClaimType': 'http://schemas.xmlsoap.org/customGroupClaimType', 'LocalClaimType': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'}]}"
                 SigningCertificateThumbPrint = "F3229E7CCA1DA812E29284B0ED75A9A019A83B08"
                 ClaimProviderName            = "LDAPCP"
                 ProviderSignOutUri           = "https://adfs.contoso.com/adfs/ls/"

--- a/Modules/SharePointDsc/Examples/Resources/SPTrustedIdentityTokenIssuer/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPTrustedIdentityTokenIssuer/1-Example.ps1
@@ -20,7 +20,17 @@
                 Realm                        = "https://sharepoint.contoso.com"
                 SignInUrl                    = "https://adfs.contoso.com/adfs/ls/"
                 IdentifierClaim              = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-                ClaimsMappings               = "{'Mappings': [{'Name': 'Email', 'IncomingClaimType': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'}, {'Name': 'Role', 'IncomingClaimType': 'http://schemas.xmlsoap.org/customGroupClaimType', 'LocalClaimType': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'}]}"
+                ClaimsMappings               = @(
+                    MSFT_SPClaimTypeMapping{
+                        Name = "Email"
+                        IncomingClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+                    }
+                    MSFT_SPClaimTypeMapping{
+                        Name = "Role"
+                        IncomingClaimType = "http://schemas.xmlsoap.org/ExternalSTSGroupType"
+                        LocalClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+                    }
+                )
                 SigningCertificateThumbPrint = "F3229E7CCA1DA812E29284B0ED75A9A019A83B08"
                 ClaimProviderName            = "LDAPCP"
                 ProviderSignOutUri           = "https://adfs.contoso.com/adfs/ls/"

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPTrustedIdentityTokenIssuer.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPTrustedIdentityTokenIssuer.Tests.ps1
@@ -20,10 +20,10 @@ Describe "SPTrustedIdentityTokenIssuer - SharePoint Build $((Get-Item $SharePoin
             Realm                        = "https://sharepoint.contoso.com"
             SignInUrl                    = "https://adfs.contoso.com/adfs/ls/"
             IdentifierClaim              = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-            ClaimsMappings               = "{'mappings': [{'Name': 'Email', 'IncomingClaimType': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'}, {'Name': 'Role', 'IncomingClaimType': 'http://schemas.xmlsoap.org/customGroupClaimType', 'LocalClaimType': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'}]}"
+            ClaimsMappings               = "{'Mappings': [{'Name': 'Email', 'IncomingClaimType': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'}, {'Name': 'Role', 'IncomingClaimType': 'http://schemas.xmlsoap.org/customGroupClaimType', 'LocalClaimType': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'}]}"
             SigningCertificateThumbPrint = "Mock Thumbrpint"
-            ClaimProviderName            = "ldapcp"
-            ProviderSignOutUri            = "https://adfs.contoso.com/adfs/ls/"
+            ClaimProviderName            = "LDAPCP"
+            ProviderSignOutUri           = "https://adfs.contoso.com/adfs/ls/"
             Ensure                       = "Present"
             Verbose                      = $true
         }

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPTrustedIdentityTokenIssuer.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPTrustedIdentityTokenIssuer.Tests.ps1
@@ -20,17 +20,7 @@ Describe "SPTrustedIdentityTokenIssuer - SharePoint Build $((Get-Item $SharePoin
             Realm                        = "https://sharepoint.contoso.com"
             SignInUrl                    = "https://adfs.contoso.com/adfs/ls/"
             IdentifierClaim              = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-            ClaimsMappings               = @(
-                (New-CimInstance -ClassName "MSFT_KeyValuePair" -ClientOnly -Property @{
-                    Name = "Email"; 
-                    IncomingClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
-                }),
-                (New-CimInstance -ClassName "MSFT_KeyValuePair" -ClientOnly -Property @{
-                    Name = "Account name"; 
-                    IncomingClaimType = "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"; 
-                    LocalClaimType = "http://schemas.xmlsoap.org/customSPGroupClaimType"
-                })
-            )
+            ClaimsMappings               = "{'mappings': [{'Name': 'Email', 'IncomingClaimType': 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'}, {'Name': 'Role', 'IncomingClaimType': 'http://schemas.xmlsoap.org/customGroupClaimType', 'LocalClaimType': 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'}]}"
             SigningCertificateThumbPrint = "Mock Thumbrpint"
             ClaimProviderName            = "ldapcp"
             ProviderSignOutUri            = "https://adfs.contoso.com/adfs/ls/"


### PR DESCRIPTION
* Changed parameter ClaimsMappings in SPTrustedIdentityTokenIssuer to use an array of custom class MSFT_SPClaimTypeMapping 
* Changed SPTrustedIdentityTokenIssuer to throw an exception if certificate specified has a private key, since SharePoint doesn't accept it
* Fixed issue with SPTrustedIdentityTokenIssuer to stop if cmdlet New-SPTrustedIdentityTokenIssuer returns null
* Fixed issue with SPTrustedIdentityTokenIssuer to correctly get parameters ClaimProviderName and ProviderSignOutUri
* Fixed issue with SPTrustedIdentityTokenIssuer to effectively remove the SPTrustedAuthenticationProvider from all zones before deleting the SPTrustedIdentityTokenIssuer
* Updated code in SPTrustedIdentityTokenIssuer to respect style guidelines

- [x] Change details added to Unreleased section of changelog.md?
- [x] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/395)
<!-- Reviewable:end -->
