### PR TITLE
Add a loop to wait unitl Prereq Installer is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Fixed issue with SPShellAdmin and Content Database method
  * Added .Net 4.6 support check to SPInstall and SPInstallPrereqs
  * Improved code styling
+ * Wait for Prerequisite Installer, if is not immediately after reboot ready (e.g on a network share)
 
 ### 1.3
  * Fixed typo on return value in SPServiceAppProxyGroup

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -141,9 +141,9 @@ function Get-TargetResource
 
     # This is the first access to the installer binary. If not yet exist (e.g. network share) give it a some time
     $retrycount = 3
-    while (-not (Test-Path $InstallerPath) -and $retrycount -gt 0)
+    while (-not (Test-Path -Path $InstallerPath) -and $retrycount -gt 0)
     {
-        sleep 10
+        sleep -Seconds 10
         $retrycount--
     }
     

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -140,11 +140,11 @@ function Get-TargetResource
     )
 
     # This is the first access to the installer binary. If not yet exist (e.g. network share) give it a some time
-    $retrycount = 3
-    while (-not (Test-Path -Path $InstallerPath) -and $retrycount -gt 0)
+    $retryCount = 3
+    while (-not (Test-Path -Path $InstallerPath) -and $retryCount -gt 0)
     {
         sleep -Seconds 10
-        $retrycount--
+        $retryCount--
     }
     
     Write-Verbose -Message "Getting installation status of SharePoint prerequisites"

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -138,6 +138,14 @@ function Get-TargetResource
         [System.String] 
         $Ensure = "Present"
     )
+
+    # This is the first access to the installer binary. If not yet exist (e.g. network share) give it a some time
+    $retrycount = 3
+    while (-not (Test-Path $InstallerPath) -and $retrycount -gt 0)
+    {
+        sleep 10
+        $retrycount--
+    }
     
     Write-Verbose -Message "Getting installation status of SharePoint prerequisites"
 

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPInstallPrereqs.Tests.ps1
@@ -476,7 +476,7 @@ Describe "SPInstallPrereqs - SharePoint Build $((Get-Item $SharePointCmdletModul
                 $pathExits = $false
                 Mock Install-WindowsFeature { @( @{ Name = "ExampleFeature"; Success = $true ; restartneeded = "no"})  }
                 Mock Start-Process { return @{ ExitCode = 0 } }
-                Mock Test-Path -ParameterFilter {$testParams.InstallerPath} {$res = $pathExits; $pathExits = $true; return $res}
+                Mock Test-Path -ParameterFilter {$Path -eq $testParams.InstallerPath} {$res = $pathExits; $pathExits = $true; return $res}
                 Mock Sleep
 
                 Get-TargetResource @testParams


### PR DESCRIPTION
I have my Prereq Installer on a share and this share is not immediately after reboot ready. If I set DSC to reboot automatically, the Module fails.

I added a wait loop for this purpure for the first access to the InstallerPath.

I was unable to create a issue (Submit Button was grayed out), so I can discuss this front up.

The delay and timeout is currently not configurable. Should this changed?

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/425)
<!-- Reviewable:end -->
