### PR TITLE
Fixed bug when search centre site doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
  * New resources: SPAppStoreSettings
  * Fixed bug with SPInstallPrereqs to allow minor version changes to prereqs for SP2016
  * Refactored unit tests to consolidate and streamline test approaches
+ * Fixed a bug that would cause SPSearchResultSource to throw exceptions when the enterprise search centre URL has not been set
 
 ### 1.3
  * Fixed typo on return value in SPServiceAppProxyGroup

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchResultSource.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchResultSource.Tests.ps1
@@ -112,7 +112,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         }  
 
         # Test contexts
-        Context -Name "A search result source doesn't exist and should" {
+        Context -Name "A search result source doesn't exist and should" -Fixture {
             $testParams = @{
                 Name = "Test source"
                 SearchServiceAppName = "Search Service Application"
@@ -137,7 +137,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name "A search result source exists and should" {
+        Context -Name "A search result source exists and should" -Fixture {
             $testParams = @{
                 Name = "Test source"
                 SearchServiceAppName = "Search Service Application"
@@ -164,7 +164,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name "A search result source exists and shouldn't" {
+        Context -Name "A search result source exists and shouldn't" -Fixture {
             $testParams = @{
                 Name = "Test source"
                 SearchServiceAppName = "Search Service Application"
@@ -195,7 +195,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name "A search result source doesn't exist and shouldn't" {
+        Context -Name "A search result source doesn't exist and shouldn't" -Fixture {
             $testParams = @{
                 Name = "Test source"
                 SearchServiceAppName = "Search Service Application"
@@ -213,6 +213,33 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             It "Should return true from the test method" {
                 Test-TargetResource @testParams | Should Be $true
+            }
+        }
+
+        Context -Name "The search centre site collection does not exist when trying to set a result source" -Fixture {
+            $testParams = @{
+                Name = "Test source"
+                SearchServiceAppName = "Search Service Application"
+                ProviderType = "Remote SharePoint Provider"
+                Query = "{searchTerms}"
+                ConnectionUrl = "https://sharepoint.contoso.com"
+                Ensure = "Present"
+            }
+
+            Mock -CommandName Get-SPWeb -MockWith {
+                return $null
+            }
+
+            It "Should return absent from the get method" {
+                (Get-TargetResource @testParams).Ensure | Should Be "Absent"
+            }
+
+            It "Should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "Should throw an exception trying to create the result source in the set method" {
+                { Set-TargetResource @testParams } | Should throw
             }
         }
     }


### PR DESCRIPTION
Added a more meaningful error to SPSearchResultSource when the enterprise search centre URL site collection doesn't exist

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines]?(https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/436)
<!-- Reviewable:end -->
