### PR TITLE
Fixed default proxy group issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Fixed bug in SPInstallLanguagePack where language packs could not be installed
   on SharePoint 2016
 * Updated SPDatabaseAAG to allow database name patterns
+* Fixed a bug were PerformancePoint and Excel Services Service Application
+  proxies would not be added to the default proxy group when they are
+  provisioned
 
 ## 1.4
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPExcelServiceApp/MSFT_SPExcelServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPExcelServiceApp/MSFT_SPExcelServiceApp.psm1
@@ -330,7 +330,8 @@ function Set-TargetResource
             $params = $args[0]
 
             New-SPExcelServiceApplication -Name $params.Name `
-                                          -ApplicationPool $params.ApplicationPool
+                                          -ApplicationPool $params.ApplicationPool `
+                                          -Default
         }
     }
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPPerformancePointServiceApp/MSFT_SPPerformancePointServiceApp.psm1
@@ -156,7 +156,8 @@ function Set-TargetResource
                 $pName = $params.ProxyName
             }
             New-SPPerformancePointServiceApplicationProxy -Name $pName `
-                                                          -ServiceApplication $params.Name 
+                                                          -ServiceApplication $params.Name `
+                                                          -Default
         }
     }
 


### PR DESCRIPTION
Minor fix to excel services and performance point to add proxies to the default proxy group when they are provisioned.

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/468)
<!-- Reviewable:end -->
