### PR TITLE
Added failed test summary to test runs

### DIFF
--- a/.appveyor/appveyor.psm1
+++ b/.appveyor/appveyor.psm1
@@ -39,7 +39,21 @@ function Start-AppveyorTestScriptTask
                           $testResultsFilePath)
     
     if ($result.FailedCount -gt 0) 
-    { 
+    {
+        Write-Output -InputObject "Failed test result summary:"
+        $result.TestResult | Where-Object -FilterScript { 
+            $_.Passed -eq $false 
+        } | ForEach-Object -Process {
+            Write-Output -InputObject "-----------------------------------------------------------"
+            $outputObject = @{
+                Context = $_.Context
+                Describe = $_.Describe
+                Name = $_.Name
+                FailureMessage = $_.FailureMessage
+            }
+            New-Object -TypeName PSObject -Property $outputObject | Format-List
+        }
+
         throw "$($result.FailedCount) tests failed."
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   returned correctly
 * Improved runtime of SPSearchTopology by streamlining wait processes
 * Fixed bug with SPSearchServiceApp that would throw an error about SDDL string
+* Improved output of test results for AppVeyor and VS Code based test runs
 
 ## 1.5
 


### PR DESCRIPTION
Fixes #492 

Let me know if you think this will do it @ykuijs - the output should look like this:

> Failed test result summary:
> -----------------------------------------------------------
> 
> Context        : SharePointDsc whole of module tests
> Name           : Should not have errors in any markdown files
> Describe       : Validate example files
> FailureMessage : The variable '$mdIssuesPath' cannot be retrieved because it has not been set.

It'll loop and show all the failures in the one spot at the bottom of the test run.

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/503)
<!-- Reviewable:end -->
