### PR TITLE
Updated MSFT_SPSearchFIleType.schema.mof to make ServiceAppName a Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * New resource: SPPowerPointAutomationServiceApp
-* Bugfix 542 in SPSearchFileType for ServiceAppName schema changing setting to Key.
+* Bugfix in SPSearchFileType  made ServiceAppName a key property.
 * New resource: SPWebApplicationExtension
 * Added new resource SPAccessServices2010
 * Bugfix in SPWebAppThrottlingSettings for setting large list window time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Bugfix 542 in SPSearchFileType for ServiceAppName schema changing setting to Key.
 * New resource: SPWebApplicationExtension
 * Added new resource SPAccessServices2010
 * Bugfix in SPWebAppThrottlingSettings for setting large list window time.

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchFileType/MSFT_SPSearchFileType.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchFileType/MSFT_SPSearchFileType.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SPSearchFileType : OMI_BaseResource
 {
     [Key, Description("The name of the file type")] string FileType;
-    [Required, Description("The name of the search service application")] string ServiceAppName;
+    [Key, Description("The name of the search service application")] string ServiceAppName;
     [Write, Description("The description of the file type")] string Description;
     [Write, Description("The mime type of the file type")] string MimeType;
     [Write, Description("The state of the file type")] boolean Enabled;


### PR DESCRIPTION
#542 

Updated the MOF schema of this resource to make serviceappName a key, instead of just required. Should resolve the issue that I had earlier.

- [x] Change details added to Unreleased section of changelog.md?
- [x] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [x] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/543)
<!-- Reviewable:end -->
