### PR TITLE
Bugfix in SPContentDatabase for setting WarningSiteCount as 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * New resource: SPSearchCrawlerImpactRule
 * Fixed bug in SPCreateFarm and SPJoinFarm when a SharePoint Server is already
   joined to a farm
+* Bugfix in SPContentDatabase for setting WarningSiteCount as 0.
 
 ## 1.6
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPContentDatabase/MSFT_SPContentDatabase.psm1
@@ -257,7 +257,7 @@ function Set-TargetResource
                  }
                  
                  # Check and change site count settings
-                if ($params.WarningSiteCount -and $params.WarningSiteCount -ne $cdb.WarningSiteCount)
+                if ($params.WarningSiteCount -ne $null -and $params.WarningSiteCount -ne $cdb.WarningSiteCount)
                 {
                     $cdb.WarningSiteCount = $params.WarningSiteCount
                 }


### PR DESCRIPTION
I couldn't set WarningSiteCount as 0 because 0 is false in PowerShell. So I changed "if($params.WarningSiteCount)" to "if($params.WarningSiteCount) -ne $null".

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/564)
<!-- Reviewable:end -->
