### PR TITLE
Update MSFT_SPSearchIndexPartition.schema.mof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Update SPSearchIndexPartition made ServiceAppName as a Key
 * New resouce: SPTrustedRootAuthority
 * Update SPFarmSolution to eject from loop after 30m.
 * New resource: SPMachineTranslationServiceApp

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchIndexPartition/MSFT_SPSearchIndexPartition.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchIndexPartition/MSFT_SPSearchIndexPartition.schema.mof
@@ -4,6 +4,6 @@ class MSFT_SPSearchIndexPartition : OMI_BaseResource
     [Key, Description("The number of the partition in this farm")] Uint32 Index;
     [Required, Description("A list of the servers that this partition should exist on")] String Servers[];
     [Write, Description("The directory that the index should use locally on each server to store data")] String RootDirectory;
-    [Required, Description("The name of the search service application")] String ServiceAppName;
+    [Key, Description("The name of the search service application")] String ServiceAppName;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };


### PR DESCRIPTION
Updated the ServiceAppName as the index value can be 0 for multiple Search Service Applications. 
Having an issue where I have two search Services in a farm, but in DSC configuration cannot set both Index values of the SPSearchIndexPartition to zero. It is creating both index partitions, one for each search service, but the index value that is created is 0, not 1, causing an issue when the configuration re-applies.

- [ ] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/567)
<!-- Reviewable:end -->
