### PR TITLE
Fixed issue with search topology and servers that don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 * Fixing verbose message that identifies SP2016 as 2013 in MSFT_SPFarm
 * Fixed SPProductUpdate looking for OSearch15 in SP2016 when stopping services
 * Added TermStoreAdministrators property to SPManagedMetadataServiceApp
+* Fixed an issue in SPSearchTopology that would leave a corrupt topology in
+  place if a server was removed and re-added to a farm
 
 ## 1.6
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
@@ -397,6 +397,17 @@ function Set-TargetResource
             }
         }
 
+        # Look for components that have no server name and remove them
+        $idsWithNoName = (Get-SPEnterpriseSearchComponent -SearchTopology $newTopology | `
+                            Where-Object -FilterScript {
+                                $null -eq $_.ServerName
+                            }).ComponentId
+        $idsWithNoName | ForEach-Object -Process {
+            Get-SPEnterpriseSearchComponent -SearchTopology $newTopology -Identity $_ | `
+                Remove-SPEnterpriseSearchComponent -SearchTopology $newTopology `
+                                                   -confirm:$false
+        }
+
         # Apply the new topology to the farm
         Set-SPEnterpriseSearchTopology -Identity $newTopology
     }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
@@ -403,7 +403,11 @@ function Set-TargetResource
                                 $null -eq $_.ServerName
                             }).ComponentId
         $idsWithNoName | ForEach-Object -Process {
-            Get-SPEnterpriseSearchComponent -SearchTopology $newTopology -Identity $_ | `
+            $id = $_
+            Get-SPEnterpriseSearchComponent -SearchTopology $newTopology | `
+                Where-Object -FilterScript {
+                    $_.ComponentId -eq $id
+                } | `
                 Remove-SPEnterpriseSearchComponent -SearchTopology $newTopology `
                                                    -confirm:$false
         }

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
@@ -355,6 +355,79 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 { Set-TargetResource @testParams } | Should Throw 
             }
         }
+
+        Context -Name "A search topology exists that has a server with a new ID in it" -Fixture {
+            $newServerId = New-Guid
+            $adminComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.AdminComponent
+            $adminComponent.ServerName = $null
+            $adminComponent.ServerId = $newServerId
+            $adminComponent.ComponentId = [Guid]::NewGuid()
+
+            $crawlComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.CrawlComponent
+            $crawlComponent.ServerName = $null
+            $crawlComponent.ServerId = $newServerId
+            $crawlComponent.ComponentId = [Guid]::NewGuid()
+
+            $contentProcessingComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.ContentProcessingComponent
+            $contentProcessingComponent.ServerName = $null
+            $contentProcessingComponent.ServerId = $newServerId
+            $contentProcessingComponent.ComponentId = [Guid]::NewGuid()
+
+            $analyticsProcessingComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.AnalyticsProcessingComponent
+            $analyticsProcessingComponent.ServerName = $null
+            $analyticsProcessingComponent.ServerId = $newServerId
+            $analyticsProcessingComponent.ComponentId = [Guid]::NewGuid()
+
+            $queryProcessingComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.QueryProcessingComponent
+            $queryProcessingComponent.ServerName = $null
+            $queryProcessingComponent.ServerId = $newServerId
+            $queryProcessingComponent.ComponentId = [Guid]::NewGuid()
+
+            $indexComponent = New-Object Microsoft.Office.Server.Search.Administration.Topology.IndexComponent
+            $indexComponent.ServerName = $null
+            $indexComponent.ServerId = $newServerId
+            $indexComponent.IndexPartitionOrdinal = 0
+
+             $testParams = @{
+                ServiceAppName          = "Search Service Application"
+                Admin                   = @($env:COMPUTERNAME)
+                Crawler                 = @($env:COMPUTERNAME)
+                ContentProcessing       = @($env:COMPUTERNAME)
+                AnalyticsProcessing     = @($env:COMPUTERNAME)
+                QueryProcessing         = @($env:COMPUTERNAME)
+                IndexPartition          = @($env:COMPUTERNAME)
+                FirstPartitionDirectory = "I:\SearchIndexes\0"
+            }
+
+            Mock -CommandName Get-SPEnterpriseSearchComponent -MockWith {
+                return @(
+                    $adminComponent, 
+                    $crawlComponent, 
+                    $contentProcessingComponent, 
+                    $analyticsProcessingComponent, 
+                    $queryProcessingComponent, 
+                    $indexComponent)
+            }
+
+            Mock -CommandName Get-SPEnterpriseSearchServiceInstance  {
+                return @{
+                    Server = @{
+                        Address = $env:COMPUTERNAME
+                    }
+                    Status = "Online"
+                }
+            }
+
+            It "Should return false from the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "Should update the topology in the set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled Remove-SPEnterpriseSearchComponent -Times 5
+                Assert-MockCalled Set-SPEnterpriseSearchTopology
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This fix will allow the search topology resource to remove components from a topology that don't have a server name (this happens when the server is removed from the farm).

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/586)
<!-- Reviewable:end -->
