### PR TITLE
Added support to set windows search service accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Fixed missing brackets in error message in SPExcelServiceApp
 * Removed the requirement for the ConfigWizard in SPInstallLanguagePack
 * Fixed Language Pack detection issue in SPInstallLanguagePack
+* Added support to set Windows service accounts for search related services to
+  SPSearchServiceApp resource
 
 ## 1.7.0.0
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchServiceApp/MSFT_SPSearchServiceApp.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchServiceApp/MSFT_SPSearchServiceApp.schema.mof
@@ -10,6 +10,7 @@ class MSFT_SPSearchServiceApp : OMI_BaseResource
     [Write, Description("The default content access account for this search service app"), EmbeddedInstance("MSFT_Credential")] String DefaultContentAccessAccount;
     [Write, Description("Should this search service application be a cloud based service app")] boolean CloudIndex;
     [Write, Description("Present if the service app should exist, absent if it should not"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Sets the windows services for search to run as this account"), EmbeddedInstance("MSFT_Credential")] string WindowsServiceAccount;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };
 


### PR DESCRIPTION
Added an option to specify which service account should be used for the search and search host controller windows services to SPSearchServiceApp

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/626)
<!-- Reviewable:end -->
