### PR TITLE
new resource, SPServiceIdentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for SharePointDsc
 
+## Unreleased
+
+* New resource: SPServiceIdentity
+
 ## 1.8
 
 * Fixed issue in SPServiceAppProxyGroup causing some service names to return as null

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.psm1
@@ -4,9 +4,17 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $Name,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] $ManagedAccount
+        [parameter(Mandatory = $true)]  
+        [System.String]
+        $Name,
+
+        [parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)] 
+        [System.String] 
+        $ManagedAccount
     )
 
     Write-Verbose -Message "Getting identity for service instance '$Name'"
@@ -16,12 +24,17 @@ function Get-TargetResource
         
 
         $serviceInstance = Get-SPServiceInstance -Server $env:computername | Where-Object { $_.TypeName -eq $params.Name }
+        
+        if ($null -eq $serviceInstance.service.processidentity) 
+        {
+            Write-Verbose "WARNING: Service $($params.name) does not support setting the process identity"
+        }
+        
         $ManagedAccount = $serviceInstance.service.processidentity.username
         
         return @{
             Name = $params.Name
             ManagedAccount = $ManagedAccount
-            InstallAccount = $params.InstallAccount
         }     
         
     }
@@ -35,9 +48,17 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $Name,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] $ManagedAccount
+        [parameter(Mandatory = $true)]  
+        [System.String] 
+        $Name,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)] 
+        [System.String] 
+        $ManagedAccount
     )
 
     Write-Verbose -Message "Setting service instance '$Name' to '$ManagedAccount'"
@@ -48,14 +69,17 @@ function Set-TargetResource
 
         $serviceInstance = Get-SPServiceInstance -Server $env:COMPUTERNAME| Where-Object { $_.TypeName -eq $params.Name }
         $managedAccount = Get-SPManagedAccount $params.ManagedAccount
-        if ($null -eq $serviceInstance) {
+        if ($null -eq $serviceInstance) 
+        {
             throw [System.Exception] "Unable to locate service $($params.Name)"
         }
-        if ($null -eq $managedAccount) {
+        if ($null -eq $managedAccount) 
+        {
             throw [System.Exception] "Unable to locate Managed Account $($params.ManagedAccount)"
         }
         
-       if ($null -eq $serviceInstance.service.processidentity) {
+       if ($null -eq $serviceInstance.service.processidentity) 
+       {
            throw [System.Exception] "Service $($params.name) does not support setting the process identity"
        }
        
@@ -76,9 +100,17 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]  [System.String] $Name,
-        [parameter(Mandatory = $false)] [System.Management.Automation.PSCredential] $InstallAccount,
-        [parameter(Mandatory = $false)] [System.String] $ManagedAccount
+        [parameter(Mandatory = $true)]  
+        [System.String]
+        $Name,
+
+        [parameter(Mandatory = $false)] 
+        [System.Management.Automation.PSCredential] 
+        $InstallAccount,
+
+        [parameter(Mandatory = $true)] 
+        [System.String] 
+        $ManagedAccount
     )
 
   $CurrentValues = Get-TargetResource @PSBoundParameters

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
@@ -2,6 +2,6 @@
 class MSFT_SPServiceIdentity : OMI_BaseResource
 {
     [Key, Description("The name of the service instance to manage")] string Name;
-    [Write, Description("The user name of a managed account that will be used to run the service") ] string ManagedAccount;
+    [Required, Description("The user name of a managed account that will be used to run the service") ] string ManagedAccount;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SPServiceIdentity")]
+class MSFT_SPServiceIdentity : OMI_BaseResource
+{
+    [Key, Description("The name of the service instance to manage")] string Name;
+    [Write, Description("The user name of a managed account that will be used to run the service") ] string ManagedAccount;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+};

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/readme.md
@@ -1,6 +1,6 @@
 # Description
 
-This resource is used to specify a managed account to be used to run a service instance. 
-The name is the typename of the service as shown in the Central Admin website. This resource only needs to
-be run on one server in the farm, as the process identity update method will apply the settings to all instances 
-of the service.
+This resource is used to specify a managed account to be used to run a service instance.
+The name is the typename of the service as shown in the Central Admin website.
+This resource only needs to be run on one server in the farm, as the process identity
+update method will apply the settings to all instances of the service.

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/readme.md
@@ -1,0 +1,6 @@
+# Description
+
+This resource is used to specify a managed account to be used to run a service instance. 
+The name is the typename of the service as shown in the Central Admin website. This resource only needs to
+be run on one server in the farm, as the process identity update method will apply the settings to all instances 
+of the service.

--- a/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
@@ -10,4 +10,4 @@
         ManagedAccount = "CONTOSO\SPUserCode"
         InstallAccount = $InstallAccount
     }
-*/
+    

--- a/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
@@ -4,10 +4,23 @@
     The account must already be registered as a managed account.
 #>
 
-    SPServiceIdentity SandBoxUserAccount
-    {  
-        Name           = "Microsoft SharePoint Foundation Sandboxed Code Service"
-        ManagedAccount = "CONTOSO\SPUserCode"
-        InstallAccount = $InstallAccount
+Configuration Example 
+    {
+        param(
+            [Parameter(Mandatory = $true)]
+            [PSCredential]
+            $SetupAccount
+        )
+
+ Import-DscResource -ModuleName SharePointDsc
+
+        node localhost {
+ 
+            SPServiceIdentity SandBoxUserAccount
+            {  
+                Name           = "Microsoft SharePoint Foundation Sandboxed Code Service"
+                ManagedAccount = "CONTOSO\SPUserCode"
+                InstallAccount = $InstallAccount
+            }
+        }
     }
-    

--- a/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
@@ -1,0 +1,13 @@
+<#
+.EXAMPLE
+    This example shows how to set the SandBox Code Service to run under a specifed service account. 
+    The account must already be registered as a managed account.
+#>
+
+    SPServiceIdentity SandBoxUserAccount
+    {  
+        Name           = "Microsoft SharePoint Foundation Sandboxed Code Service"
+        ManagedAccount = "CONTOSO\SPUserCode"
+        InstallAccount = $InstallAccount
+    }
+*/

--- a/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPServiceIdentity/1-Example.ps1
@@ -20,7 +20,7 @@ Configuration Example
             {  
                 Name           = "Microsoft SharePoint Foundation Sandboxed Code Service"
                 ManagedAccount = "CONTOSO\SPUserCode"
-                InstallAccount = $InstallAccount
+                PsDscRunAsCredential = $SetupAccount
             }
         }
     }

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPServiceIdentity.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPServiceIdentity.Tests.ps1
@@ -1,0 +1,236 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string] 
+    $SharePointCmdletModule = (Join-Path -Path $PSScriptRoot `
+                                         -ChildPath "..\Stubs\SharePoint\15.0.4805.1000\Microsoft.SharePoint.PowerShell.psm1" `
+                                         -Resolve)
+)
+
+Import-Module -Name (Join-Path -Path $PSScriptRoot `
+                                -ChildPath "..\UnitTestHelper.psm1" `
+                                -Resolve)
+
+$Global:SPDscHelper = New-SPDscUnitTestHelper -SharePointStubModule $SharePointCmdletModule `
+                                              -DscResource "SPServiceIdentity"
+
+Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:SPDscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
+
+        #Initialize tests
+        Add-Type -TypeDefinition @"
+    namespace Microsoft.SharePoint.Administration 
+    {
+        public class IdentityType
+        {
+            public string SpecificUser { get; set; } 
+        }
+    }
+"@
+
+
+        # Mocks for all contexts
+        Mock -CommandName Get-SPManagedAccount -MockWith { 
+            return "CONTOSO\svc.c2wts"
+        }
+
+        # Test contexts
+        Context -Name "Service is set to use the specified identity" -Fixture {
+           
+            $testParams = @{
+                Name = "Claims to Windows Token Service"
+                ManagedAccount = "CONTOSO\svc.c2wts"
+            }
+
+            Mock -CommandName Get-SPServiceInstance -MockWith { 
+               $ProcessIdentity = @{
+                   username = $testParams.ManagedAccount
+               }
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Update -Value {
+                   $Global:SPDscSPServiceInstanceUpdateCalled = $true
+               } -PassThru
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Deploy -Value {
+               } -PassThru
+
+               $ServiceIdentity = @{
+                                TypeName = $testParams.Name
+                                Service = @{
+                                    processidentity = $ProcessIdentity
+                                }
+                            }
+               
+               return $ServiceIdentity
+            }
+            
+            It "Should return the current identity from the get method" { 
+                (Get-TargetResource @testParams).ManagedAccount | Should Not BeNullOrEmpty
+          
+            }
+
+            It "Should return true for the test method" {
+                Test-TargetResource @testParams | Should Be $true
+            }
+        }
+
+        Context -Name "Service is not set to use the specified identity" -Fixture {
+
+            $testParams = @{
+                Name = "Claims to Windows Token Service"
+                ManagedAccount = "CONTOSO\svc.c2wts"
+            }
+
+            Mock -CommandName Get-SPServiceInstance -MockWith { 
+               $ProcessIdentity = @{
+                   username = "NT AUTHORITY\SYSTEM"
+               }
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Update -Value {
+                   $Global:SPDscSPServiceInstanceUpdateCalled = $true
+               } -PassThru
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Deploy -Value {
+               } -PassThru
+
+               $ServiceIdentity = @{
+                                TypeName = $testParams.Name
+                                Service = @{
+                                    processidentity = $ProcessIdentity
+                                }
+                            }
+               
+               return $ServiceIdentity
+            }
+            
+            It "Should return the current identity from the get method" { 
+                (Get-TargetResource @testParams).ManagedAccount | Should Not BeNullOrEmpty
+            }
+
+            It "Should return false for the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            $Global:SPDscSPServiceInstanceUpdateCalled = $false
+            It "Should call the SPServiceInstance update method" {
+                Set-TargetResource @testParams
+                $Global:SPDscSPServiceInstanceUpdateCalled | Should Be $true 
+            }
+
+        }
+
+        Context -Name "Invalid Service Specified" -Fixture {
+           
+            $testParams = @{
+                Name = "No Such Windows Token Service"
+                ManagedAccount = "CONTOSO\svc.c2wts"
+            }
+
+            Mock -CommandName Get-SPServiceInstance -MockWith { 
+               return $null
+            }
+            
+            It "Should return null from the get method" { 
+                (Get-TargetResource @testParams).ManagedAccount | Should BeNullOrEmpty
+          
+            }
+
+            It "Should return false for the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "Should throw an error for the set method" {
+                {Set-TargetResource @testParams} | Should throw "Unable to locate service $($testParams.name)"
+            }
+        }
+
+        Context -Name "Invalid managed account specified" -Fixture {
+           
+            $testParams = @{
+                Name = "Claims to Windows Token Service"
+                ManagedAccount = "CONTOSO\svc.badAccount"
+            }
+
+            Mock -CommandName Get-SPManagedAccount -MockWith {
+                return $null
+            }
+
+            Mock -CommandName Get-SPServiceInstance -MockWith { 
+               $ProcessIdentity = @{
+                   username = "CONTOSO\svc.c2wts"
+               }
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Update -Value {
+                   $Global:SPDscSPServiceInstanceUpdateCalled = $true
+               } -PassThru
+
+               $ProcessIdentity = $ProcessIdentity | Add-Member -MemberType ScriptMethod -Name Deploy -Value {
+               } -PassThru
+
+               $ServiceIdentity = @{
+                                TypeName = $testParams.Name
+                                Service = @{
+                                    processidentity = $ProcessIdentity
+                                }
+                            }
+               
+               return $ServiceIdentity
+            }
+            
+            It "Should return the current identity from the get method" { 
+                (Get-TargetResource @testParams).ManagedAccount | Should Not BeNullOrEmpty
+          
+            }
+
+            It "Should return false for the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "Should throw an error for the set method" {
+                {Set-TargetResource @testParams} | Should throw "Unable to locate Managed Account $($testParams.ManagedAccount)"
+            }
+        }
+
+        Context -Name "Service does not support setting process identity" -Fixture {
+           
+            $testParams = @{
+                Name = "Machine Translation Service"
+                ManagedAccount = "CONTOSO\svc.mts"
+            }
+
+            Mock -CommandName Get-SPManagedAccount -MockWith {
+                return $null
+            }
+            
+            Mock -CommandName Get-SPServiceInstance -MockWith { 
+               $ServiceIdentity = @{
+                                TypeName = $testParams.Name
+                                Service = @{
+                                    TypeName = $testParams.Name
+                                }
+                            }
+               
+               return $ServiceIdentity
+            }
+            
+            It "Should return null for the current identity from the get method" { 
+                (Get-TargetResource @testParams).ManagedAccount | Should BeNullOrEmpty
+            }
+
+            It "Should return false for the test method" {
+                Test-TargetResource @testParams | Should Be $false
+            }
+
+            It "Should throw an error for the set method" {
+                 Mock -CommandName Get-SPManagedAccount -MockWith { 
+                     return "CONTOSO\svc.mts"
+                 }
+                 {Set-TargetResource @testParams} | Should throw "Service $($testParams.name) does not support setting the process identity"
+            }
+        }
+    }
+
+}
+
+Invoke-Command -ScriptBlock $Global:SPDscHelper.CleanupScript -NoNewScope


### PR DESCRIPTION
new resource, SPServiceInstanceIdentity
 used to set SP services that support it (C2WTS, Sandbox service, Excel Services, etc..) to run on the server as a specified managed account, as descried in issue #577 

- [X] Change details added to Unreleased section of changelog.md?
- [X] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [X] Examples updated for both the single server and small farm templates in the examples folder?
- [X] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [X] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/642)
<!-- Reviewable:end -->
