### PR TITLE
Update to MSFT_SPBlobCacheSettings.psm1

### DIFF
--- a/Modules/SharePointDsc/DSCResources/MSFT_SPBlobCacheSettings/MSFT_SPBlobCacheSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPBlobCacheSettings/MSFT_SPBlobCacheSettings.psm1
@@ -238,7 +238,7 @@ function Set-TargetResource
 
             $webappsi = Get-SPServiceInstance -Server $env:COMPUTERNAME `
                                               -ErrorAction SilentlyContinue `
-                            | Where-Object -FilterScript {
+                           | Where-Object -FilterScript {
                                 $_.TypeName -eq "Microsoft SharePoint Foundation Web Application"
                               }
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPBlobCacheSettings/MSFT_SPBlobCacheSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPBlobCacheSettings/MSFT_SPBlobCacheSettings.psm1
@@ -254,6 +254,7 @@ function Set-TargetResource
                 throw "Specified web application could not be found."
             }
 
+
             Write-Verbose -Message "Processing changes"
 
             $zone = [Microsoft.SharePoint.Administration.SPUrlZone]::$($params.Zone)
@@ -286,8 +287,7 @@ function Set-TargetResource
 
             if ($changes.ContainsKey("MaxAgeInSeconds")) 
             {
-                $webconfig.configuration.SharePoint.BlobCache."max-age" `
-                    = $changes.MaxAgeInSeconds.ToString()
+                $webconfig.configuration.SharePoint.BlobCache.SetAttribute("max-age",$($changes.MaxAgeInSeconds.ToString()))
             }
             
             if ($changes.ContainsKey("FileTypes")) 


### PR DESCRIPTION
In Set-TargetResource configuring the max-age attribute in a few farm fails because this attribute is not part of the default Blob Cache attributes and $webconfig.configuration.SharePoint.BlobCache."max-age"  = $changes.MaxAgeInSeconds.ToString() only updates an existing attribute and will not create a new one. The following error message is seen in the console:

PowerShell DSC resource MSFT_SPBlobCacheSettings  failed to execute Set-TargetResource functionality with error
message: Exception setting "max-age": "The property 'max-age' cannot be found on this object. Verify that the property
exists and can be set."
    + CategoryInfo          : InvalidOperation: (:) [], CimException
    + FullyQualifiedErrorId : ProviderOperationExecutionFailure
    + PSComputerName        : localhost

Fix:
Updated the max-age section to use the following, which will create the attribute if it does not exist and update it if it does exist.
$webconfig.configuration.SharePoint.BlobCache.SetAttribute("max-age",$($changes.MaxAgeInSeconds.ToString()))

Thanks for submitting a Pull Request to this project.
This template will help you create your pull request.

Please make sure you have read the [Contribution Guidelines](https://github.com/powershell/xSharePoint/wiki/Contributing%20to%20xSharePoint).

To aid community reviewers in reviewing and merging your PR, please take the time to run through this checklist:

**DELETE THIS LINE AND ABOVE**

[Replace this with a description of your pull request]

- [ ] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

**DELETE THIS LINE AND BELOW**

Your contribution to this project is greatly appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/671)
<!-- Reviewable:end -->
