### PR TITLE
New  resource "SPManagedMetadataServiceAppDefault" to solve issue 674

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0
 
 * Added resource: SPMinRoleCompliance, SPWebAppSuiteBar, SPWebAppPeoplePickerSettings,
-  SPLogLevel, SPWorkflowService
+  SPLogLevel, SPWorkflowService, SPManagedMetadataAppDefault
 * Added support for Project Server 2016 with the following new resources:
   SPProjectServerLicense, SPProjectServerAdditionalSettings,
   SPProjectServerADResourcePoolSync, SPProjectServerGlobalPermissions,
@@ -78,6 +78,9 @@ The following changes will break 1.x configurations that use these resources:
 * Changed implementation of the Web Application authentication configuration.
   A new resource (SPWebAppAuthentication) has been added and existing properties
   have been removed from SPWebApplication and SPWebApplicationExtension
+* Changed implementation of SPManagedMetadataServiceApp resource. This resource
+  will not set any defaults for the keyword and site collection term store. The
+  new resource SPManagedMetadataServiceAppDefault has to be used for this setting.
 
 ## 1.9
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceApp/MSFT_SPManagedMetaDataServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceApp/MSFT_SPManagedMetaDataServiceApp.psm1
@@ -281,7 +281,7 @@ function Set-TargetResource
             -Arguments ($PSBoundParameters, $pName) `
             -ScriptBlock {
             $params = $args[0]
-            $pName = $args[1]
+            $pName = $args[1    ]
 
             $newParams = @{
                 Name            = $params.Name
@@ -301,9 +301,7 @@ function Set-TargetResource
                 New-SPMetadataServiceApplicationProxy -Name $pName `
                     -ServiceApplication $app `
                     -DefaultProxyGroup `
-                    -ContentTypePushdownEnabled `
-                    -DefaultKeywordTaxonomy `
-                    -DefaultSiteCollectionTaxonomy
+                    -ContentTypePushdownEnabled
             }
         }
         $result = Get-TargetResource @PSBoundParameters

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
@@ -1,0 +1,186 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultSiteCollectionProxyName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultKeywordProxyName,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    Write-Verbose -Message "Getting the default site collection and keyword term store settings"
+
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+        -Arguments $PSBoundParameters `
+        -ScriptBlock {
+
+        $params = $args[0]
+
+        $serviceAppProxies = Get-SPServiceApplicationProxy -ErrorAction SilentlyContinue
+
+        if ($null -eq $serviceAppProxies)
+        {
+            return @{
+                IsSingleInstance               = $params.IsSingleInstance
+                DefaultSiteCollectionProxyName = ""
+                DefaultKeywordProxyName        = ""
+                InstallAccount                 = $params.InstallAccount
+            }
+        }
+        else
+        {
+            $serviceAppProxies | Where-Object -FilterScript {
+                $_.GetType().FullName -eq "Managed Metadata Service Connection"
+            }
+
+            $defaultSiteCollectionProxy = ""
+            foreach($serviceAppProxy in $serviceAppProxies)
+            {
+                if($serviceAppProxy.Properties["IsDefaultKeywordTaxonomy"] -eq $true)
+                {
+                    if($defaultSiteCollectionProxy -eq "")
+                    {
+                        $defaultSiteCollectionProxy = $serviceAppProxy.Name
+                    }
+                    else
+                    {
+                        $defaultSiteCollectionProxy = $null
+                    }
+                }
+
+                $defaultKeywordProxy = ""
+                if($serviceAppProxy.Properties["IsDefaultSiteCollectionTaxonomy"] -eq $true)
+                {
+                    if($defaultKeywordProxy -eq "")
+                    {
+                        $defaultKeywordProxy = $serviceAppProxy.Name
+                    }
+                    else
+                    {
+                        $defaultKeywordProxy = $null
+                    }
+                }
+            }
+        }
+
+        return @{
+            IsSingleInstance               = $params.IsSingleInstance
+            DefaultSiteCollectionProxyName = ""
+            DefaultKeywordProxyName        = ""
+            InstallAccount                 = $params.InstallAccount
+        }
+    }
+    return $result
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultSiteCollectionProxyName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultKeywordProxyName,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    Write-Verbose -Message "Setting the default site collection and keyword term store settings"
+
+    $result = Get-TargetResource @PSBoundParameters
+
+    $result = Invoke-SPDSCCommand -Credential $InstallAccount `
+    -Arguments $PSBoundParameters `
+    -ScriptBlock {
+
+    $params = $args[0]
+
+    $serviceAppProxies | Where-Object -FilterScript {
+        $_.GetType().FullName -eq "Managed Metadata Service Connection"
+    }
+
+    foreach($serviceAppProxy in $serviceAppProxies)
+    {
+        $proxyName = $serviceAppProxy.Name
+
+        $serviceAppProxy.Properties["IsDefaultKeywordTaxonomy"] = $false
+        $serviceAppProxy.Properties["IsDefaultSiteCollectionTaxonomy"] = $false
+
+        if($proxyName -eq $params.DefaultKeywordProxyName)
+        {
+            $serviceAppProxy.Properties["IsDefaultKeywordTaxonomy"] = $true
+        }
+
+        if($proxyName -eq $params.DefaultSiteCollectionProxyName)
+        {
+            $serviceAppProxy.Properties["IsDefaultSiteCollectionTaxonomy"] = $true
+        }
+    }
+}
+
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultSiteCollectionProxyName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DefaultKeywordProxyName,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $InstallAccount
+    )
+
+    Write-Verbose -Message "Testing the default site collection and keyword term store settings"
+
+    $valuesToCheck = @(
+        "DefaultSiteCollectionProxyName",
+        "DefaultKeywordProxyName"
+    )
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+
+    return Test-SPDscParameterState -CurrentValues $CurrentValues `
+        -DesiredValues $PSBoundParameters `
+        -ValuesToCheck $valuesToCheck
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
@@ -78,7 +78,6 @@ function Get-TargetResource
                     $defaultKeywordProxy = $null
                 }
             }
-
         }
 
         return @{
@@ -150,7 +149,6 @@ function Set-TargetResource
             $serviceAppProxy.Update()
         }
     }
-
 }
 
 function Test-TargetResource

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.schema.mof
@@ -1,0 +1,8 @@
+[ClassVersion("1.0.0.0"), FriendlyName("SPManagedMetaDataServiceAppDefault")]
+class MSFT_SPManagedMetaDataServiceAppDefault : OMI_BaseResource
+{
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Required, Description("The name of the managed metadata service application proxy used as default column terms set")] String DefaultSiteCollectionProxyName;
+    [Required, Description("The name of the managed metadata service application proxy used as default keyword terms set")] String DefaultKeywordProxyName;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+};

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
@@ -1,9 +1,9 @@
 # Description
 
-Using several managed metadata service instances in a fram requires some
-onfiguration, which service application proxy should be used as default
+Using several managed metadata service instances in a farm requires some
+configuration, which service application proxy should be used as default
 for keywords or site collection specific term sets.
 
 This setting has to be configured in conjunction with the SPManagedMetadataServiceApp
-resource. This resource allows to speicify which managed metadata service application
-porxy should be used as default for these two settings.
+resource. This resource allows to specify which managed metadata service application
+proxy should be used as default for these two settings.

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
@@ -1,0 +1,9 @@
+# Description
+
+Using several managed metadata service instances in a fram requires some
+onfiguration, which service application proxy should be used as default
+for keywords or site collection specific term sets.
+
+This setting has to be configured in conjunction with the SPManagedMetadataServiceApp
+resource. This resource allows to speicify which managed metadata service application
+porxy should be used as default for these two settings.

--- a/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
@@ -1,0 +1,24 @@
+<#
+.EXAMPLE
+    This example shows how to deploy the Managed Metadata service app to the local SharePoint farm.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $SetupAccount
+    )
+    Import-DscResource -ModuleName SharePointDsc
+
+    node localhost {
+        SPManagedMetaDataServiceAppDefault ManagedMetadataServiceAppDefault
+        {
+            IsSingleInstance               = "Yes"
+            DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
+            DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
+            InstallAccount                 = $SetupAccount
+        }
+    }
+}

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
@@ -73,7 +73,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             )
         }
 
-        Context -Name "Wehn no service application proxy or managed metadata service application proxy exist in the farm" -Fixture {
+        Context -Name "When no service application proxy or managed metadata service application proxy exist in the farm" -Fixture {
             $testParams = @{
                 IsSingleInstance               = "Yes"
                 DefaultSiteCollectionProxyName = "DefaultSiteCollectionProxyName"
@@ -253,6 +253,5 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         }
     }
 }
-
 
 Invoke-Command -ScriptBlock $Global:SPDscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
@@ -18,8 +18,241 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:SPDscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
 
+        $getTypeFullName = "Managed Metadata Service Connection"
 
+        $managedMetadataServiceApplicationProxy = @{
+            TypeName   = "Managed Metadata Service Connection"
+            Name       = "Managed Metadata Service Application Proxy"
+            Properties = @{
+                IsDefaultSiteCollectionTaxonomy = $false
+                IsDefaultKeywordTaxonomy        = $false
+            }
+        } `
+            | Add-Member -MemberType ScriptMethod `
+            -Name Update `
+            -Value { `
+                $Global:SPDscServiceProxyUpdateCalled = $true
+        } `
+            -PassThru -Force `
+            | Add-Member -MemberType ScriptMethod `
+            -Name GetType `
+            -Value { `
+                return (@{
+                    FullName = $getTypeFullName
+                }) `
+        } `
+            -PassThru -Force
+
+        $managedMetadataServiceApplicationProxyDefault = @{
+            TypeName   = "Managed Metadata Service Connection"
+            Name       = "Managed Metadata Service Application Proxy Default"
+            Properties = @{
+                IsDefaultSiteCollectionTaxonomy = $true
+                IsDefaultKeywordTaxonomy        = $true
+            }
+        } `
+            | Add-Member -MemberType ScriptMethod `
+            -Name Update `
+            -Value { `
+                $Global:SPDscServiceProxyUpdateCalledDefault = $true `
+        } `
+            -PassThru -Force `
+            | Add-Member -MemberType ScriptMethod `
+            -Name GetType `
+            -Value { `
+                return (@{
+                    FullName = $getTypeFullName
+                }) `
+        } `
+            -PassThru -Force
+
+        Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+            return @(
+                $managedMetadataServiceApplicationProxy,
+                $managedMetadataServiceApplicationProxyDefault
+            )
+        }
+
+        Context -Name "Wehn no service application proxy or managed metadata service application proxy exist in the farm" -Fixture {
+            $testParams = @{
+                IsSingleInstance               = "Yes"
+                DefaultSiteCollectionProxyName = "DefaultSiteCollectionProxyName"
+                DefaultKeywordProxyName        = "DefaultKeywordProxyName"
+            }
+
+            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+                return $null
+            }
+
+            It "Should throw an error, when no Service Application Proxy is available" {
+                { Get-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxy available in the farm"
+            }
+
+            $mockProxy = @{
+                TypeName = "Mock Proxy"
+                Name     = "Mock Proxy"
+
+            } `
+                | Add-Member -MemberType ScriptMethod `
+                -Name GetType `
+                -Value { `
+                    return (@{
+                        FullName = "Mock Proxy"
+                    }) `
+            } `
+                -PassThru -Force
+
+            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+                return @(
+                    $mockProxy
+                )
+            }
+
+            It "Should throw an error, when no Service Application Proxy is available" {
+                { Get-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxy available in the farm"
+            }
+        }
+
+        Context -Name "When one managed metadata service application proxy exists and should be the default" -Fixture {
+            $testParams = @{
+                IsSingleInstance               = "Yes"
+                DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
+                DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
+            }
+
+            $managedMetadataServiceApplicationProxyMock = @{
+                TypeName   = "Managed Metadata Service Connection"
+                Name       = "Managed Metadata Service Application Proxy"
+                Properties = @{
+                    IsDefaultSiteCollectionTaxonomy = $false
+                    IsDefaultKeywordTaxonomy        = $false
+                }
+            } `
+                | Add-Member -MemberType ScriptMethod `
+                -Name Update `
+                -Value { `
+                    $Global:SPDscServiceProxyUpdateCalled = $true
+            } `
+                -PassThru -Force `
+                | Add-Member -MemberType ScriptMethod `
+                -Name GetType `
+                -Value { `
+                    return (@{
+                        FullName = $getTypeFullName
+                    }) `
+            } `
+                -PassThru -Force
+
+            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+                return @(
+                    $managedMetadataServiceApplicationProxyMock
+                )
+            }
+
+            It "Should return false when the test method is called" {
+                Test-TargetResource @testParams | Should be $false
+            }
+
+            It "Should return null, as the proxy is not configured properly" {
+                $result = Get-TargetResource @testParams
+                $result.DefaultKeywordProxyName | Should Be $null
+                $result.DefaultSiteCollectionProxyName | Should Be $null
+            }
+
+            It "Should set the defaults" {
+                $Global:SPDscServiceProxyUpdateCalled = $false
+
+                Set-TargetResource @testParams
+
+                $managedMetadataServiceApplicationProxyMock.Properties["IsDefaultKeywordTaxonomy"] | Should Be $true
+                $managedMetadataServiceApplicationProxyMock.Properties["IsDefaultSiteCollectionTaxonomy"] | Should Be $true
+                $Global:SPDscServiceProxyUpdateCalled | Should Be $true
+            }
+        }
+
+        Context -Name "When several managed metadata service application proxy exists and another should be the default" -Fixture {
+            $testParams = @{
+                IsSingleInstance               = "Yes"
+                DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
+                DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
+            }
+
+            It "Should return false when the test method is called" {
+                Test-TargetResource @testParams | Should be $false
+            }
+
+            It "Should return the default proxy" {
+                $result = Get-TargetResource @testParams
+                $result.DefaultKeywordProxyName | Should Be "Managed Metadata Service Application Proxy Default"
+                $result.DefaultSiteCollectionProxyName | Should Be "Managed Metadata Service Application Proxy Default"
+            }
+
+            It "Should set the defaults" {
+                $Global:SPDscServiceProxyUpdateCalled = $false
+                $Global:SPDscServiceProxyUpdateCalledDefault = $false
+
+                Set-TargetResource @testParams
+
+                $managedMetadataServiceApplicationProxy.Properties["IsDefaultKeywordTaxonomy"] | Should Be $true
+                $managedMetadataServiceApplicationProxy.Properties["IsDefaultSiteCollectionTaxonomy"] | Should Be $true
+
+                $managedMetadataServiceApplicationProxyDefault.Properties["IsDefaultKeywordTaxonomy"] | Should Be $false
+                $managedMetadataServiceApplicationProxyDefault.Properties["IsDefaultSiteCollectionTaxonomy"] | Should Be $false
+
+                $Global:SPDscServiceProxyUpdateCalled | Should Be $true
+                $Global:SPDscServiceProxyUpdateCalledDefault | Should Be $true
+            }
+        }
+
+        Context -Name "When several managed metadata service application proxy exists, both are default" -Fixture {
+            $testParams = @{
+                IsSingleInstance               = "Yes"
+                DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
+                DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
+            }
+
+            $managedMetadataServiceApplicationProxyDefault = @{
+                TypeName   = "Managed Metadata Service Connection"
+                Name       = "Managed Metadata Service Application Proxy Default"
+                Properties = @{
+                    IsDefaultSiteCollectionTaxonomy = $true
+                    IsDefaultKeywordTaxonomy        = $true
+                }
+            } `
+                | Add-Member -MemberType ScriptMethod `
+                -Name Update `
+                -Value { `
+                    $Global:SPDscServiceProxyUpdateCalledDefault = $true `
+            } `
+                -PassThru -Force `
+                | Add-Member -MemberType ScriptMethod `
+                -Name GetType `
+                -Value { `
+                    return (@{
+                        FullName = $getTypeFullName
+                    }) `
+            } `
+                -PassThru -Force
+
+            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+                return @(
+                    $managedMetadataServiceApplicationProxyDefault,
+                    $managedMetadataServiceApplicationProxyDefault
+                )
+            }
+
+            It "Should return false when the test method is called" {
+                Test-TargetResource @testParams | Should be $false
+            }
+
+            It "Should return null" {
+                $result = Get-TargetResource @testParams
+                $result.DefaultKeywordProxyName | Should Be $null
+                $result.DefaultSiteCollectionProxyName | Should Be $null
+            }
+        }
     }
 }
+
 
 Invoke-Command -ScriptBlock $Global:SPDscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]
+    $SharePointCmdletModule = (Join-Path -Path $PSScriptRoot `
+            -ChildPath "..\Stubs\SharePoint\15.0.4805.1000\Microsoft.SharePoint.PowerShell.psm1" `
+            -Resolve)
+)
+
+Import-Module -Name (Join-Path -Path $PSScriptRoot `
+        -ChildPath "..\UnitTestHelper.psm1" `
+        -Resolve)
+
+$Global:SPDscHelper = New-SPDscUnitTestHelper -SharePointStubModule $SharePointCmdletModule `
+    -DscResource "SPManagedMetaDataServiceAppDefault"
+
+Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:SPDscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
+
+
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:SPDscHelper.CleanupScript -NoNewScope


### PR DESCRIPTION
New Resource to solve issue #674 .
The SPManagedMetadataServiceApp resource always sets the proxy as default for site collections and keywords. This behavior leads to issues in farms with several managed metadata service applications. A new resource SPManagedMetadataServiceAppDefault is used to set the defaults properly.

- [x] Change details added to Unreleased section of changelog.md?
- [x] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [x] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

**Any chance anybody could run a integration test with the new resource. Currently my dev environment is not accessible.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/699)
<!-- Reviewable:end -->
