### PR TITLE
Additional support to allow SPAlternateUrl to update Default Zone URL for Central Administration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     * Updated the SqlServer configuration to use SqlServerDsc version 10.0.0.0.
 * SPAlternateURL
   * Added the ability to manage the Central Administration AAMs
+  * If resource specifies Central Admin webapp and Default Zone, the existing AAM will be updated instead of adding a new one
 * SPDiagnosticsProvider
   * Added the resource
 * SPFarm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * SPAlternateURL
-  * If resource specifies Central Admin webapp and Default Zone, the existing AAM will be updated instead of adding a new one
+  * If resource specifies Central Admin webapp and Default Zone, the existing
+    AAM will be updated instead of adding a new one
 
 ## 2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for SharePointDsc
 
+## Unreleased
+
+* SPAlternateURL
+  * If resource specifies Central Admin webapp and Default Zone, the existing AAM will be updated instead of adding a new one
+
 ## 2.1
 
 * General
@@ -8,7 +13,6 @@
     * Updated the SqlServer configuration to use SqlServerDsc version 10.0.0.0.
 * SPAlternateURL
   * Added the ability to manage the Central Administration AAMs
-  * If resource specifies Central Admin webapp and Default Zone, the existing AAM will be updated instead of adding a new one
 * SPDiagnosticsProvider
   * Added the resource
 * SPFarm

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
@@ -165,20 +165,14 @@ function Set-TargetResource
                    if ($null -eq $urlAam)
                     {
                         # urlAAM not found, so it is safe to create AAM on specified zone (or modify existing if CA)
-                        # If this is Central Admin, we want to update the existing Default AAM instead of adding a new one
+                        # If this is Central Admin and Default zone, we want to update the existing AAM instead of adding a new one
                         if ($webapp.IsAdministrationWebApplication -and $params.Zone -eq "Default")
                         {
-                            # web app is Central Administration
-                            # assumptions we have to make to proceed without introducing breaking changes:
-                            # 1. CA only has 1 AAM
-                            #    update: this shouldn't matter -- if CA has more than 1 AAM in Default zone, Set-SPAlternateUrl should consolidate into 1
-                            #            For additional CA servers, use other zones instead of Default
-                            #
-                            # sanity checks before updating AAM:
-                            # 1. We are editing the Default Zone AAM (done in if condition above)
-                            # 2. Internal URL == Public URL (does this matter? we could still set both to the new URL)
-                            #    update: if $webAppAams is an array (more than 1 AAM in Default zone), maybe this is the best way to find the primary AAM to use
-                            #            OR, maybe the best way is to ask CA for its URL (RECOMMENDED)
+                            # web app is Central Administration and Default zone
+
+                            # If CA has more than 1 AAM in Default zone, Set-SPAlternateUrl should consolidate into 1
+                            # For additional CA servers, use other zones instead of Default
+
                             Set-SPAlternateURL -Identity $webApp.Url -Url $params.Url -Zone $params.Zone | Out-Null
                         }
                         else

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
@@ -171,8 +171,7 @@ function Set-TargetResource
                             # web app is Central Administration
                             # assumptions we have to make to proceed without introducing breaking changes:
                             # 1. CA only has 1 AAM (done in if condition above)
-
-
+                            #
                             # sanity checks before updating AAM:
                             # 1. We are editing the Default Zone AAM (done in if condition above)
                             # 2. Internal URL == Public URL (does this matter? we could still set both to the new URL)

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/MSFT_SPAlternateUrl.psm1
@@ -166,23 +166,20 @@ function Set-TargetResource
                     {
                         # urlAAM not found, so it is safe to create AAM on specified zone (or modify existing if CA)
                         # If this is Central Admin, we want to update the existing Default AAM instead of adding a new one
-                        if ($webapp.IsAdministrationWebApplication -and $params.Zone -eq "Default" -and !$webAppAams.GetType().IsArray)
+                        if ($webapp.IsAdministrationWebApplication -and $params.Zone -eq "Default")
                         {
                             # web app is Central Administration
                             # assumptions we have to make to proceed without introducing breaking changes:
-                            # 1. CA only has 1 AAM (done in if condition above)
+                            # 1. CA only has 1 AAM
+                            #    update: this shouldn't matter -- if CA has more than 1 AAM in Default zone, Set-SPAlternateUrl should consolidate into 1
+                            #            For additional CA servers, use other zones instead of Default
                             #
                             # sanity checks before updating AAM:
                             # 1. We are editing the Default Zone AAM (done in if condition above)
                             # 2. Internal URL == Public URL (does this matter? we could still set both to the new URL)
-                            if ($webAppAams.IncomingUrl -eq $webAppAams.PublicUrl)
-                            {
-                                Set-SPAlternateURL -Identity $webAppAams.IncomingUrl -Url $params.Url | Out-Null
-                            }
-                            else
-                            {
-                                throw("Central Administration's existing AAM has different values for Internal and Public URL's")
-                            }
+                            #    update: if $webAppAams is an array (more than 1 AAM in Default zone), maybe this is the best way to find the primary AAM to use
+                            #            OR, maybe the best way is to ask CA for its URL (RECOMMENDED)
+                            Set-SPAlternateURL -Identity $webApp.Url -Url $params.Url -Zone $params.Zone | Out-Null
                         }
                         else
                         {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
@@ -5,11 +5,25 @@ web application. These can be assigned to specific zones for each web
 application. Alternatively a URL can be removed from a zone to ensure that it
 will remain empty and have no alternate URL.
 
+The default value for the Ensure parameter is Present. When not specifying this
+parameter, the setting is configured.
+
+# Central Administration
+
 To select the Central Administration site, use the following command to retrieve
 the correct web application name:
 (Get-SPWebApplication -IncludeCentralAdministration | Where-Object {
      $_.IsAdministrationWebApplication
  }).DisplayName
 
-The default value for the Ensure parameter is Present. When not specifying this
-parameter, the setting is configured.
+ To update the existing Default Zone AAM for Central Administration (e.g. to
+ implement HTTPS), use the above command to retrieve the web application name
+ (by default, it will be "SharePoint Central Administration v4") and specify
+ "Default" as the Zone. If you wish to add AAM's instead, you may use the other
+ zones to do so.
+
+Using SPAlternateUrl to update the Default Zone AAM for Central Administration
+will update the AAM in SharePoint as well as the CentralAdministrationUrl value
+in the registry. It will not, however, update bindings in IIS. It is recommended
+to use the xWebsite resource from the xWebAdministration module to configure the
+appropriate bindings in IIS.

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
@@ -16,11 +16,11 @@ the correct web application name:
      $_.IsAdministrationWebApplication
  }).DisplayName
 
- To update the existing Default Zone AAM for Central Administration (e.g. to
- implement HTTPS), use the above command to retrieve the web application name
- (by default, it will be "SharePoint Central Administration v4") and specify
- "Default" as the Zone. If you wish to add AAM's instead, you may use the other
- zones to do so.
+To update the existing Default Zone AAM for Central Administration (e.g. to
+implement HTTPS), use the above command to retrieve the web application name
+(by default, it will be "SharePoint Central Administration v4") and specify
+"Default" as the Zone. If you wish to add AAM's instead, you may use the other
+zones to do so.
 
 Using SPAlternateUrl to update the Default Zone AAM for Central Administration
 will update the AAM in SharePoint as well as the CentralAdministrationUrl value

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPAlternateUrl/readme.md
@@ -8,7 +8,7 @@ will remain empty and have no alternate URL.
 The default value for the Ensure parameter is Present. When not specifying this
 parameter, the setting is configured.
 
-# Central Administration
+## Central Administration
 
 To select the Central Administration site, use the following command to retrieve
 the correct web application name:


### PR DESCRIPTION
When the SPAlternateUrl resource specifies Central Administration web app and the Default Zone, we should use Set-SPAlternateUrl to update the existing AAM instead of New-SPAlternateUrl to create a new one. Adding logic to handle this case. I have included notes in the readme with details of the new behavior, and a suggestion to use xWebsite from xWebAdministration to update IIS bindings since that's the only piece that Set-SPAlternateUrl does not touch.

I will take a look at the tests section, but would certainly appreciate some suggestions on how best to add test cases since I'm still getting up to speed on writing these.

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/767)
<!-- Reviewable:end -->
