### PR TITLE
Fix SPManagedMetadataServiceApp - TypeName vs. .GetType().FullName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
     AAM will be updated instead of adding a new one
 * SPVisioServiceApp
   * Fixed an issue where the proxy is not properly getting created
+* SPManagedMetadataServiceAppDefault
+  * Fixed issue where .GetType().FullName and TypeName were not used
+  properly
 
 ## 2.1
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
         }
 
         $serviceAppProxies = $serviceAppProxies | Where-Object -FilterScript {
-            $_.GetType().FullName -eq "Managed Metadata Service Connection"
+            $_.GetType().FullName -eq "Microsoft.SharePoint.Taxonomy.MetadataWebServiceApplicationProxy"
         }
 
         if ($null -eq $serviceAppProxies)
@@ -126,7 +126,7 @@ function Set-TargetResource
         $serviceAppProxies = Get-SPServiceApplicationProxy -ErrorAction SilentlyContinue
 
         $serviceAppProxies = $serviceAppProxies | Where-Object -FilterScript {
-            $_.GetType().FullName -eq "Managed Metadata Service Connection"
+            $_.GetType().FullName -eq "Microsoft.SharePoint.Taxonomy.MetadataWebServiceApplicationProxy"
         }
 
         foreach ($serviceAppProxy in $serviceAppProxies)

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
@@ -18,7 +18,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:SPDscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:SPDscHelper.InitializeScript -NoNewScope
 
-        $getTypeFullName = "Managed Metadata Service Connection"
+        $getTypeFullName = "Microsoft.SharePoint.Taxonomy.MetadataWebServiceApplicationProxy"
 
         $managedMetadataServiceApplicationProxy = @{
             TypeName   = "Managed Metadata Service Connection"


### PR DESCRIPTION
closes #779 .

Fixed usage of .GetType().FullName vs. TypeName.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/780)
<!-- Reviewable:end -->
