### PR TITLE
Fix: Timer jobs rolled out to multiple WebApps could not be configured via SPTimerJobState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * Added the resource.
 * SPUserProfileServiceApp
   * Now supported specifying the host Managed path, and properly sets the host.
+* SPTimerJobState
+  * Fixed issue where the Set method for timerjobs deployed to multiple web
+    applications failed.
 
 ## 2.2
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
@@ -160,7 +160,7 @@ function Set-TargetResource
             }
 
             $timerjob = Get-SPTimerJob -Type $params.TypeName `
-                                        -WebApplication $webapp
+                                        -WebApplication $wa
             
             if ($timerjob.Count -eq 0)
             {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPTimerJobState/MSFT_SPTimerJobState.psm1
@@ -61,7 +61,7 @@ function Get-TargetResource
             }
     
             $timerjob = Get-SPTimerJob -Type $params.TypeName `
-                                        -WebApplication $params.WebAppUrl
+                                        -WebApplication $wa
             
             if ($timerjob.Count -eq 0)
             {


### PR DESCRIPTION
This PR fixes a small bug: The variable used in Get-SPTimerJob for the web application was never set.

This is not a problem if a TimerJob is only rolled out on one webapplication, because then only one object is returned. However, as soon as the same TimerJob has been rolled out to more than one webapplication, activating/deactivating, for example, no longer works.

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/800)
<!-- Reviewable:end -->
