### PR TITLE
Fix get of ups

### DIFF
--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileServiceApp/MSFT_SPUserProfileServiceApp.psm1
@@ -95,9 +95,8 @@ function Get-TargetResource
                 $localaccount = "$($Env:USERDOMAIN)\$($Env:USERNAME)"
                 if ($localaccount -eq $farmAccount.UserName)
                 {
-                    throw ("Specified PSDSCRunAsCredential ($localaccount) is the Farm " + `
-                           "Account. Make sure the specified PSDSCRunAsCredential isn't the " + `
-                           "Farm Account and try again")
+                    Write-Verbose -Message ("The current user ($localaccount) is the Farm " + `
+                           "Account.")
                 }
             }
         }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
@@ -93,19 +93,8 @@ function Get-TargetResource
             $upcm = New-Object -TypeName "Microsoft.Office.Server.UserProfiles.UserProfileConfigManager" `
                                -ArgumentList $context
 
-            # In SP2016, the forest name is used as name but the dot is replaced by a dash
-            $installedVersion = Get-SPDSCInstalledProductVersion
-            if ($installedVersion.FileMajorPart -eq 16)
-            {
-                $Name = $params.Forest -replace "\.", "-"
-            }
-            else
-            {
-                $Name = $params.Name
-            }
-
             $connection = $upcm.ConnectionManager | Where-Object -FilterScript {
-                $_.DisplayName -eq $Name
+                $_.DisplayName -eq $params.Name
             }
             if ($null -eq $connection)
             {
@@ -339,19 +328,8 @@ function Set-TargetResource
             throw "Synchronization is in Progress."
         }
 
-        # In SP2016, the forest name is used as name but the dot is replaced by a dash
-        $installedVersion = Get-SPDSCInstalledProductVersion
-        if ($installedVersion.FileMajorPart -eq 16)
-        {
-            $Name = $Forest -replace "\.", "-"
-        }
-        else
-        {
-            $Name = $params.Name
-        }
-
         $connection = $upcm.ConnectionManager | Where-Object -FilterScript {
-            $_.DisplayName -eq $Name
+            $_.DisplayName -eq $params.Name
         } | Select-Object -first 1
 
         if ($null -ne $connection -and $params.Forest -ieq  $connection.Server)

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
@@ -93,16 +93,8 @@ function Get-TargetResource
             $upcm = New-Object -TypeName "Microsoft.Office.Server.UserProfiles.UserProfileConfigManager" `
                                -ArgumentList $context
 
-            if($null -ne $params.Name)
-            {
-                $Name = $params.Name
-            }
-            else
-            {
-                $Name = $params.Forest.Replace(".", "-")
-            }
             $connection = $upcm.ConnectionManager | Where-Object -FilterScript {
-                $_.DisplayName -eq $Name
+                $_.DisplayName -eq $params.Name
             }
             if ($null -eq $connection)
             {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
@@ -93,8 +93,16 @@ function Get-TargetResource
             $upcm = New-Object -TypeName "Microsoft.Office.Server.UserProfiles.UserProfileConfigManager" `
                                -ArgumentList $context
 
+            if($null -ne $params.Name)
+            {
+                $Name = $params.Name
+            }
+            else
+            {
+                $Name = $params.Forest.Replace(".", "-")
+            }
             $connection = $upcm.ConnectionManager | Where-Object -FilterScript {
-                $_.DisplayName -eq $params.Name
+                $_.DisplayName -eq $Name
             }
             if ($null -eq $connection)
             {
@@ -328,8 +336,16 @@ function Set-TargetResource
             throw "Synchronization is in Progress."
         }
 
+        if($null -ne $params.Name)
+        {
+            $Name = $params.Name
+        }
+        else {
+            $Name = $params.Forest.Replace(".", "-")
+        }
+
         $connection = $upcm.ConnectionManager | Where-Object -FilterScript {
-            $_.DisplayName -eq $params.Name
+            $_.DisplayName -eq $Name
         } | Select-Object -first 1
 
         if ($null -ne $connection -and $params.Forest -ieq  $connection.Server)

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileServiceApp.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileServiceApp.Tests.ps1
@@ -92,8 +92,8 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Restart-Service {}
 
-            It "Should throw exception in the Get method" {
-                { Get-TargetResource @testParams } | Should throw "Specified PSDSCRunAsCredential "
+            It "Should NOT throw exception in the Get method" {
+                { Get-TargetResource @testParams } | (Get-TargetResource @testParams).Ensure | Should Be "Present"
             }
 
             It "Should throw exception in the Test method" {

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileSyncConnection.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileSyncConnection.Tests.ps1
@@ -24,14 +24,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         $mockCredential = New-Object -TypeName System.Management.Automation.PSCredential `
                                      -ArgumentList @("DOMAIN\username", $mockPassword)
 
-        if ($Global:SPDscHelper.CurrentStubBuildNumber.Major -eq 16)
-        {
-            $name = "contoso-com"
-        }
-        else
-        {
-            $name = "contoso"
-        }
+        $name = "contoso"
 
         try { [Microsoft.Office.Server.UserProfiles] }
         catch {


### PR DESCRIPTION
Converted the error thrown by the SPUserProfileServiceApp resource when the current user is the farm account to a warning.

- [ ] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/816)
<!-- Reviewable:end -->
