### PR TITLE
Fix: SPInfoPathFormsServiceConfig - MaxSizeOfUserFormState parameter could never be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   * Fixed code styling issues
 * SPUserProfileServiceApp
   * Fixed code styling issues
+* SPInfoPathFormsServiceConfig
+  * Fixed issue with trying to set the MaxSizeOfUserFormState parameter
 
 ## 2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * SPFarm
   * Implemented ability to deploy Central Administration site to a server at a
     later point in time
+* SPInfoPathFormsServiceConfig
+  * Fixed issue with trying to set the MaxSizeOfUserFormState parameter
 * SPProjectServerLicense
   * Fixed issue with incorrect detection of the license
 * SPServiceAppSecurity
@@ -19,8 +21,6 @@
   * Fixed code styling issues
 * SPUserProfileServiceApp
   * Fixed code styling issues
-* SPInfoPathFormsServiceConfig
-  * Fixed issue with trying to set the MaxSizeOfUserFormState parameter
 
 ## 2.3
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInfoPathFormsServiceConfig/MSFT_SPInfoPathFormsServiceConfig.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInfoPathFormsServiceConfig/MSFT_SPInfoPathFormsServiceConfig.psm1
@@ -260,7 +260,7 @@ function Set-TargetResource
 
         if($params.ContainsKey("MaxSizeOfUserFormState"))
         {
-            $config.MaxSizeOfUserFormState = ($config.MaxSizeOfUserFormState * 1024)
+            $config.MaxSizeOfUserFormState = ($params.MaxSizeOfUserFormState * 1024)
         }
 
         $config.Update()


### PR DESCRIPTION
This PR fixes a bug for setting the "MaxSizeOfUserFormState" for InfoPath Forms Services. If you've tried to set this parameter it was always throwing an error and the default value was (still) used.

The assignment was basically "current value = (current value * 1024)" before.

Not sure if someone could change the test too (not familiar with testing these things, sorry).
The test uses the default value of this service application. So even if the value wasn't changed with the Set method - the tests could never reveal that because of the default value that's tested against.

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/836)
<!-- Reviewable:end -->
