### PR TITLE
Bugfix for issue 840 - SPSearchContentSource - StartHour parameter never updates anything - dev branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * SPSearchContentSource
   * Fixed issue where the Get method returned a conversion error when the content
     source contained just one address
-  * Fixed issue where the parameter StartHour was never taken into account (issue 840)
+  * Fixed issue 840 where the parameter StartHour was never taken into account 
 * SPSearchServiceApp
   * Fixed issue where the service account was not set correctly when the service
     application was first created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * SPSearchContentSource
   * Fixed issue where the Get method returned a conversion error when the content
     source contained just one address
+  * Fixed issue where the parameter StartHour was never taken into account (issue 840)
 * SPSearchServiceApp
   * Fixed issue where the service account was not set correctly when the service
     application was first created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * SPSearchContentSource
   * Fixed issue where the Get method returned a conversion error when the content
     source contained just one address
-  * Fixed issue 840 where the parameter StartHour was never taken into account 
+  * Fixed issue 840 where the parameter StartHour was never taken into account
 * SPSearchServiceApp
   * Fixed issue where the service account was not set correctly when the service
     application was first created

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchContentSource/MSFT_SPSearchContentSource.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchContentSource/MSFT_SPSearchContentSource.psm1
@@ -517,6 +517,14 @@ function Set-TargetResource
                     $incrementalSetArgs.Add("CrawlScheduleRunEveryInterval",
                         $params.IncrementalSchedule.CrawlScheduleRunEveryInterval)
                 }
+                
+                $propertyTest = Test-SPDSCObjectHasProperty -Object $params.IncrementalSchedule `
+                                                            -PropertyName "StartHour"
+                if ($propertyTest -eq $true)
+                {
+                    $incrementalSetArgs.Add("CrawlScheduleStartDateTime", 
+                        "$($params.IncrementalSchedule.StartHour):$($params.IncrementalSchedule.StartMinute)")
+                }
                 Set-SPEnterpriseSearchCrawlContentSource @allSetArguments @incrementalSetArgs
             }
 
@@ -592,6 +600,14 @@ function Set-TargetResource
                 {
                     $fullSetArgs.Add("CrawlScheduleRunEveryInterval",
                         $params.FullSchedule.CrawlScheduleRunEveryInterval)
+                }
+                
+                $propertyTest = Test-SPDSCObjectHasProperty -Object $params.FullSchedule `
+                                                            -PropertyName "StartHour"
+                if ($propertyTest -eq $true)
+                {
+                    $fullSetArgs.Add("CrawlScheduleStartDateTime", 
+                        "$($params.FullSchedule.StartHour):$($params.FullSchedule.StartMinute)")
                 }
                 Set-SPEnterpriseSearchCrawlContentSource @allSetArguments @fullSetArgs
             }


### PR DESCRIPTION
Regarding issue MSFT_SPSearchContentSource does not take StartHour parameter for schedule #840

I was able to solve this issue, but I must admit that I am a newbie regarding the pull request process...

So here it is. From what I was able to understand, the StartHour parameter is correctly checked in the test Get-SPDSCSearchCrawlSchedule.psm1 module.
The issue seems to be in the MSFT_SPSearchContentSource.psm1, as in its Set-TargetResource function there is never the parameter CrawlScheduleStartDateTime which is required by the sharepoint powershell cmdlet Set-SPEnterpriseSearchCrawlContentSource to had a start hour to the schedule.

Hope it helps.

- [x] Change details added to Unreleased section of changelog.md?
- [ ] Added/updated documentation and descriptions in .schema.mof files where appropriate?
- [ ] Examples updated for both the single server and small farm templates in the examples folder?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [ ] [Unit and Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/842)
<!-- Reviewable:end -->
