### PR TITLE
PsDscRunAsAccount should be PsDscRunAsCredential

### DIFF
--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceIdentity/MSFT_SPServiceIdentity.schema.mof
@@ -3,5 +3,5 @@ class MSFT_SPServiceIdentity : OMI_BaseResource
 {
     [Key, Description("The name of the service instance to manage")] string Name;
     [Required, Description("The user name of a managed account, LocalService, LocalSystem or NetworkService that will be used to run the service") ] string ManagedAccount;
-    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsAccount if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
+    [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };


### PR DESCRIPTION
Fixed a mistake in the documentation — assuming the wiki is generated from this; if not, someone with access should update it.

(Does this need anything in changelog.md?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/851)
<!-- Reviewable:end -->
