### PR TITLE
SPWebAppSuiteBar: Enabled usage of SuiteBarBrandingElementHtml in SharePoiont 2016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   * Fixed issues that prevented the resource to work as expected in many situations.
 * SPWebAppPropertyBag
   * New resource to manage web application property bag
+* SPWebAppSuiteBar
+  * Enable usage of SuiteBarBrandingElementHtml for SharePoint 2016
+    (only supported if using a SharePoint 2013 masterpage)
 
 ## 2.5
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/MSFT_SPWebAppSuiteBar.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/MSFT_SPWebAppSuiteBar.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
                                    -ErrorAction SilentlyContinue
 
         $returnval = @{
-            WebAppUrl = $wa.Url
+            WebAppUrl = $null
             SuiteNavBrandingLogoNavigationUrl = $null
             SuiteNavBrandingLogoTitle = $null
             SuiteNavBrandingLogoUrl = $null
@@ -57,13 +57,16 @@ function Get-TargetResource
             return $returnval
         }
 
+        $returnval.WebAppUrl = $wa.Url
+
         $installedVersion = Get-SPDSCInstalledProductVersion
 
-        if($installedVersion.FileMajorPart -eq 15)
+        if($installedVersion.FileMajorPart -ge 15)
         {
             $returnval.SuiteBarBrandingElementHtml = $wa.SuiteBarBrandingElementHtml
         }
-        elseif($installedVersion.FileMajorPart -ge 16)
+
+        if($installedVersion.FileMajorPart -ge 16)
         {
             $returnval.SuiteNavBrandingLogoNavigationUrl = $wa.SuiteNavBrandingLogoNavigationUrl
             $returnval.SuiteNavBrandingLogoTitle = $wa.SuiteNavBrandingLogoTitle
@@ -139,23 +142,22 @@ function Set-TargetResource
         }
         16
         {
-            <# Exception: The SP2013 specific SuiteBarBrandingElementHtml parameter was passed with SP2016. #>
             if($PSBoundParameters.ContainsKey("SuiteBarBrandingElementHtml"))
             {
-                throw ("Cannot specify SuiteBarBrandingElementHtml with SharePoint 2016. Instead," + `
-                                        " use the SuiteNavBrandingLogoNavigationUrl, SuiteNavBrandingLogoTitle, " + `
-                                        "SuiteNavBrandingLogoUrl and SuiteNavBrandingText parameters")
+                Write-Verbose "SuiteBarBrandingElementHtml with SharePoint 2016 only works if using a " + `
+                                        "SharePoint 2016 masterpage"
             }
 
             <# Exception: All the optional parameters are null for SP2016. #>
             if(!$PSBoundParameters.ContainsKey("SuiteNavBrandingLogoNavigationUrl") `
             -and !$PSBoundParameters.ContainsKey("SuiteNavBrandingLogoTitle") `
             -and !$PSBoundParameters.ContainsKey("SuiteNavBrandingLogoUrl") `
-            -and !$PSBoundParameters.ContainsKey("SuiteNavBrandingText"))
+            -and !$PSBoundParameters.ContainsKey("SuiteNavBrandingText") `
+            -and !$PSBoundParameters.ContainsKey("SuiteBarBrandingElementHtml"))
             {
-                throw ("You need to specify a value for either SuiteNavBrandingLogoNavigationUrl" + `
-                                        ", SuiteNavBrandingLogoTitle, SuiteNavBrandingLogoUrl and SuiteNavBrandingText " + `
-                                        "with SharePoint 2016")
+                throw ("You need to specify a value for either SuiteNavBrandingLogoNavigationUrl, " + `
+                                        "SuiteNavBrandingLogoTitle, SuiteNavBrandingLogoUrl, SuiteNavBrandingTextm, " + `
+                                        "and SuiteBarBrandingElementHtml with SharePoint 2016")
             }
         }
     }
@@ -184,11 +186,12 @@ function Set-TargetResource
 
         Write-Verbose -Message "Processing changes"
 
-        if($installedVersion.FileMajorPart -eq 15)
+        if($installedVersion.FileMajorPart -ge 15)
         {
             $wa.SuiteBarBrandingElementHtml = $params.SuiteBarBrandingElementHtml
         }
-        elseif($installedVersion.FileMajorPart -ge 16)
+
+        if($installedVersion.FileMajorPart -ge 16)
         {
             $wa.SuiteNavBrandingLogoNavigationUrl = $params.SuiteNavBrandingLogoNavigationUrl
             $wa.SuiteNavBrandingLogoTitle = $params.SuiteNavBrandingLogoTitle
@@ -255,7 +258,7 @@ function Test-TargetResource
     {
         return Test-SPDscParameterState -CurrentValues $CurrentValues `
         -DesiredValues $PSBoundParameters `
-        -ValuesToCheck @("SuiteNavBrandingLogoNavigationUrl", "SuiteNavBrandingLogoTitle", "SuiteNavBrandingLogoUrl", "SuiteNavBrandingText")
+        -ValuesToCheck @("SuiteBarBrandingElementHtml", "SuiteNavBrandingLogoNavigationUrl", "SuiteNavBrandingLogoTitle", "SuiteNavBrandingLogoUrl", "SuiteNavBrandingText")
     }
 }
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/MSFT_SPWebAppSuiteBar.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/MSFT_SPWebAppSuiteBar.schema.mof
@@ -6,6 +6,6 @@ class MSFT_SPWebAppSuiteBar : OMI_BaseResource
     [Write, Description("SP2016+: Alternative text for the Suite Bar Logo")] String SuiteNavBrandingLogoTitle;
     [Write, Description("SP2016+: URL of the logo for the Suite Bar")] String SuiteNavBrandingLogoUrl;
     [Write, Description("SP2016+: Text to display at the left hand side of the suite bar")] String SuiteNavBrandingText;
-    [Write, Description("SP2013: HTML to inject in the left hand-side of the Suite Bar")] String SuiteBarBrandingElementHtml; 
+    [Write, Description("SP2013+: HTML to inject in the left hand-side of the Suite Bar")] String SuiteBarBrandingElementHtml;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;
 };

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppSuiteBar/readme.md
@@ -8,7 +8,6 @@ applications. It supports both the SharePoint 2013 and SharePoint
 
 Requirements:
 For SharePoint 2013, only the SuiteBarBrandingElementHtml
-should be specified, whereas for SharePoint 2016, only one
-or all of SuiteNavBrandingLogoNavigationUrl,
-SuiteNavBrandingLogoTitle, SuiteNavBrandingLogoUrl or
-SuiteNavBrandingText should be.
+should be specified, whereas for SharePoint 2016, all properties
+are supported. Note that SuiteBarBrandingElementHtml has no
+effect unless using a SharePoint 2013 master page.

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPWebAppSuiteBar.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPWebAppSuiteBar.Tests.ps1
@@ -23,6 +23,29 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         # Mocks for all contexts
 
         # Test contexts
+
+        Context -Name "Web application does not exist" -Fixture {
+            $testParams = @{
+                WebAppUrl = "http://sites.sharepoint.com"
+                SuiteBarBrandingElementHtml = "<div>Test</div>"
+            }
+
+            Mock -CommandName Get-SPWebApplication -MockWith {
+                return $null
+            }
+
+            It "Get target resource returns null value" {
+                $returnValue = Get-TargetResource @testParams
+                $returnValue | Should Not Be $null
+                $returnValue.WebAppUrl | Should Be $null
+                $returnValue.SuiteNavBrandingLogoNavigationUrl | Should Be $null
+                $returnValue.SuiteNavBrandingLogoTitle | Should Be $null
+                $returnValue.SuiteNavBrandingLogoUrl | Should Be $null
+                $returnValue.SuiteNavBrandingText | Should Be $null
+                $returnValue.SuiteBarBrandingElementHtml | Should Be $null
+            }
+        }
+
         if ($Global:SPDscHelper.CurrentStubBuildNumber.Major -eq 15)
         {
             Context -Name "Only all SP2016 parameters passed for a SP2013 environment" -Fixture {
@@ -141,6 +164,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                     SuiteNavBrandingLogoTitle = "LogoTitle"
                     SuiteNavBrandingLogoUrl = "http://sites.sharepoint.com/images/logo.gif"
                     SuiteNavBrandingText = "Suite Bar Text"
+                    SuiteBarBrandingElementHtml = "<div>Test</div>"
                 }
 
                 Mock -CommandName Get-SPWebApplication -MockWith {
@@ -151,7 +175,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                         SuiteNavBrandingLogoTitle = "LogoTitle"
                         SuiteNavBrandingLogoUrl = "http://sites.sharepoint.com/images/logo.gif"
                         SuiteNavBrandingText = "Suite Bar Text"
-                        SuiteBarBrandingElementHtml = $null
+                        SuiteBarBrandingElementHtml = "<div>Test</div>"
                     }
                     $webApp = $webApp | Add-Member -MemberType ScriptMethod -Name Update -Value {
                         $Global:SPDscWebApplicationUpdateCalled = $true
@@ -166,6 +190,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                     $results.SuiteNavBrandingLogoTitle | Should be "LogoTitle"
                     $results.SuiteNavBrandingLogoUrl | Should be "http://sites.sharepoint.com/images/logo.gif"
                     $results.SuiteNavBrandingText | Should be "Suite Bar Text"
+                    $result.SuiteBarBrandingElementHtml | Should be "<div>Test</div>"
                 }
 
                 It "Should properly configure the suite bar for the Web Application" {
@@ -192,7 +217,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                         SuiteNavBrandingLogoTitle = "LogoTitle"
                         SuiteNavBrandingLogoUrl = "http://sites.sharepoint.com/images/logo.gif"
                         SuiteNavBrandingText = "Suite Bar Text"
-                        SuiteBarBrandingElementHtml = $null
+                        SuiteBarBrandingElementHtml = "<div>Test</div>"
                     }
                     $webApp = $webApp | Add-Member -MemberType ScriptMethod -Name Update -Value {
                         $Global:SPDscWebApplicationUpdateCalled = $true


### PR DESCRIPTION
#### Pull Request (PR) description
Enabled usage of SuiteBarBrandingElementHtml in SharePoiont 2016 as this property is supported in SharePoint 2016. It does require usage of a SharePoint 2013 master page to have any effect.

#### This Pull Request (PR) fixes the following issues
    - Fixes #882

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
