### PR TITLE
Fix Issue #917 for CA service instance naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Changes to SharePointDsc
   * Updated test helpers to force a reload of the resource every time you run a test
+* SPFarm
+  * Fixed issue where Central Admin service was not starting for non-english farms
 * SPSearchContentSource
   * Fixed issue with numerical Content Sources name
 * SPSearchManagedProperty

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
@@ -164,7 +164,7 @@ function Get-TargetResource
             $centralAdminProvisioned = $false
             $ca = Get-SPServiceInstance -Server $env:ComputerName `
                   | Where-Object -Filterscript {
-                        $_.TypeName -eq "Central Administration" -and $_.Status -eq "Online"
+                        $_.Name -eq "WSS_Administration" -and $_.Status -eq "Online"
                     }
             if ($null -ne $ca)
             {
@@ -358,7 +358,7 @@ function Set-TargetResource
                 {
                     $serviceInstance = Get-SPServiceInstance -Server $env:COMPUTERNAME `
                                             | Where-Object -FilterScript {
-                                                $_.TypeName -eq "Central Administration"
+                                                $_.Name -eq "WSS_Administration"
                                             }
                     if ($null -eq $serviceInstance)
                     {
@@ -366,7 +366,7 @@ function Set-TargetResource
                         $fqdn = "$($env:COMPUTERNAME).$domain"
                         $serviceInstance = Get-SPServiceInstance -Server $fqdn `
                                             | Where-Object -FilterScript {
-                                                $_.TypeName -eq "Central Administration"
+                                                $_.Name -eq "WSS_Administration"
                                             }
                     }
                     if ($null -eq $serviceInstance)
@@ -380,7 +380,7 @@ function Set-TargetResource
                     # Unprovision central administration
                     $serviceInstance = Get-SPServiceInstance -Server $env:COMPUTERNAME `
                                                 | Where-Object -FilterScript {
-                                                    $_.TypeName -eq "Central Administration"
+                                                    $_.Name -eq "WSS_Administration"
                                                 }
                     if ($null -eq $serviceInstance)
                     {
@@ -388,7 +388,7 @@ function Set-TargetResource
                         $fqdn = "$($env:COMPUTERNAME).$domain"
                         $serviceInstance = Get-SPServiceInstance -Server $fqdn `
                                             | Where-Object -FilterScript {
-                                                $_.TypeName -eq "Central Administration"
+                                                $_.Name -eq "WSS_Administration"
                                             }
                     }
                     if ($null -eq $serviceInstance)
@@ -600,7 +600,7 @@ function Set-TargetResource
                 {
                     $serviceInstance = Get-SPServiceInstance -Server $env:COMPUTERNAME `
                                             | Where-Object -FilterScript {
-                                                $_.TypeName -eq "Central Administration"
+                                                $_.Name -eq "WSS_Administration"
                                             }
                     if ($null -eq $serviceInstance)
                     {
@@ -608,7 +608,7 @@ function Set-TargetResource
                         $fqdn = "$($env:COMPUTERNAME).$domain"
                         $serviceInstance = Get-SPServiceInstance -Server $fqdn `
                                             | Where-Object -FilterScript {
-                                                $_.TypeName -eq "Central Administration"
+                                                $_.Name -eq "WSS_Administration"
                                             }
                     }
                     if ($null -eq $serviceInstance)

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPFarm.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPFarm.Tests.ps1
@@ -188,6 +188,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 if ($global:SPDscCentralAdminCheckDone -eq $true)
                 {
                     return @(@{
+                        Name = "WSS_Administration"
                         TypeName = "Central Administration"
                     })
                 }
@@ -263,6 +264,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 if ($global:SPDscCentralAdminCheckDone -eq $true)
                 {
                     return @(@{
+                        Name = "WSS_Administration"
                         TypeName = "Central Administration"
                     })
                 }
@@ -408,6 +410,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                             $global:SPDscSIRunCount++
                             return @(@{
                                 TypeName = "Central Administration"
+                                Name = "WSS_Administration"
                                 Status = "Online"
                             })
                         }
@@ -495,6 +498,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-SPServiceInstance -MockWith {
                 return @(@{
+                    Name = "WSS_Administration"
                     TypeName = "Central Administration"
                     Status = "Online"
                 })
@@ -574,6 +578,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                         {
                             $global:SPDscSIRunCount++
                             return @(@{
+                                Name = "WSS_Administration"
                                 TypeName = "Central Administration"
                                 Status = "Online"
                             })
@@ -658,6 +663,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 if ($global:SPDscCentralAdminCheckDone -eq $true)
                 {
                     return @(@{
+                        Name = "WSS_Administration"
                         TypeName = "Central Administration"
                         Status = "Online"
                     })
@@ -1002,6 +1008,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 if ($global:SPDscCentralAdminCheckDone -eq $true)
                 {
                     return @(@{
+                        Name = "WSS_Administration"
                         TypeName = "Central Administration"
                         Status = "Online"
                     })
@@ -1089,6 +1096,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 if ($global:SPDscCentralAdminCheckDone -eq $true)
                 {
                     return @(@{
+                        Name = "WSS_Administration"
                         TypeName = "Central Administration"
                         Status = "Online"
                     })


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes the problem where the CA service was not properly started in SPFarm when a non-english farm was used.

#### This Pull Request (PR) fixes the following issues
- Fixes #917 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/922)
<!-- Reviewable:end -->
