### PR TITLE
SPSearchTopology first partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Added a new ScopeUrl parameter to allow for local source creation
 * SPSearchTopology
   * Updated Readme.md to remove some incorrect information
+  * Fixed logic to handle the FirstPartitionDirectory in Get-TargetResource
 * SPSite
   * Added the possibility for creating the default site groups
   * Added the possibility to set AdministrationSiteType

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPSearchTopology/MSFT_SPSearchTopology.psm1
@@ -144,16 +144,23 @@ function Get-TargetResource
 
         $firstPartition = $null
         $enterpriseSearchServiceInstance = Get-SPEnterpriseSearchServiceInstance
-        if($null -ne $enterpriseSearchServiceInstance)
+        if ($null -ne $enterpriseSearchServiceInstance)
         {
             $ssiComponents = $enterpriseSearchServiceInstance.Components
-            if($null -ne $ssiComponents)
+            if ($null -ne $ssiComponents)
             {
-                if($ssiComponents.Length -gt 1)
+                if ($ssiComponents.Length -gt 1)
                 {
                     $ssiComponents = $ssiComponents[0]
                 }
-                $firstPartition = $ssiComponents.IndexLocation
+
+                if ($ssiComponents.IndexLocation.GetType().Name -eq "String")
+                {
+                    $firstPartition = $ssiComponents.IndexLocation
+                }
+                elseif ($ssiComponents.IndexLocation.GetType().Name -eq "Object[]") {
+                    $firstPartition = $ssiComponents.IndexLocation[0]
+                }
             }
         }
 

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
@@ -63,6 +63,14 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 Server = @{
                     Address = $env:COMPUTERNAME
                 }
+                Components = @(
+                    @{
+                        IndexLocation = @("C:\Program Files\Fake", "C:\Program Files\Fake2")
+                    },
+                    @{
+                        IndexLocation = @("C:\Program Files\Fake3")
+                    }
+                )
                 Status = "Online"
             }
         }

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
@@ -120,7 +120,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 AnalyticsProcessing     = @($env:COMPUTERNAME)
                 QueryProcessing         = @($env:COMPUTERNAME)
                 IndexPartition          = @($env:COMPUTERNAME)
-                FirstPartitionDirectory = "I:\SearchIndexes\0"
+                FirstPartitionDirectory = @("I:\SearchIndexes\0", "N:\SearchIndexes\1")
             }
 
             Mock -CommandName Get-SPEnterpriseSearchComponent -MockWith {

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPSearchTopology.Tests.ps1
@@ -120,7 +120,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 AnalyticsProcessing     = @($env:COMPUTERNAME)
                 QueryProcessing         = @($env:COMPUTERNAME)
                 IndexPartition          = @($env:COMPUTERNAME)
-                FirstPartitionDirectory = @("I:\SearchIndexes\0", "N:\SearchIndexes\1")
+                FirstPartitionDirectory = "I:\SearchIndexes\0"
             }
 
             Mock -CommandName Get-SPEnterpriseSearchComponent -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where some IndexLocation of existing environment had multiple values, which resulted in an array being returned. The new logic now returns the first directory, doesn't matter if its an array or a string. (Only Get-TargetResource is affected since this was a ReverseDSC discovered issue).

#### This Pull Request (PR) fixes the following issues
N/A

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/928)
<!-- Reviewable:end -->
