### PR TITLE
SPInstallPrereq: Added support for detecting updated installation of VC++ redistributable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
     Grant-SPObjectSecurity
   * Added all supported access levels as available values.
   * Removed unknown access levels: Change Permissions, Write, and Read
+* SPInstallPrereqs
+  * Added support for detecting updated installation of Microsoft Visual C++
+    2015/2017 Redistributable (x64) for SharePoint 2016 and SharePoint 2019.
 
 The following changes will break v2.x and earlier configurations that use these
 resources:

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -258,12 +258,12 @@ function Get-TargetResource
     Write-Verbose -Message "Checking windows packages from the registry"
 
     $x86Path = "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-    $installedItemsX86 = Get-ItemProperty -Path $x86Path | Select-Object -Property DisplayName
+    $installedItemsX86 = Get-ItemProperty -Path $x86Path | Select-Object -Property DisplayName, BundleUpgradeCode, DisplayVersion
 
     $x64Path = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
-    $installedItemsX64 = Get-ItemProperty -Path $x64Path | Select-Object -Property DisplayName
+    $installedItemsX64 = Get-ItemProperty -Path $x64Path | Select-Object -Property DisplayName, BundleUpgradeCode, DisplayVersion
 
-    $installedItems = $installedItemsX86 + $installedItemsX64 | Select-Object -Property DisplayName -Unique
+    $installedItems = $installedItemsX86 + $installedItemsX64 | Select-Object -Property DisplayName, BundleUpgradeCode, DisplayVersion -Unique
 
     # Common prereqs
     $prereqsToTest = @(
@@ -349,14 +349,10 @@ function Get-TargetResource
                     SearchValue = "Microsoft Visual C++ 2012 x64 Additional Runtime - 11.0.*"
                 },
                 [PSObject]@{
-                    Name = "Microsoft Visual C++ 2015 x64 Minimum Runtime - 14.0"
-                    SearchType = "Like"
-                    SearchValue = "Microsoft Visual C++ 2015 x64 Minimum Runtime - 14.0.*"
-                },
-                [PSObject]@{
-                    Name = "Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0"
-                    SearchType = "Like"
-                    SearchValue = "Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.*"
+                    Name = "Microsoft Visual C++ 2015 Redistributable (x64)"
+                    SearchType = "BundleUpgradeCode"
+                    SearchValue = "{C146EF48-4D31-3C3D-A2C5-1E91AF8A0A9B}"
+                    MinimumRequiredVersion = "14.0.23026.0"
                 }
             )
         }
@@ -375,9 +371,10 @@ function Get-TargetResource
                     SearchValue = "Microsoft SQL Server 2012 Native Client"
                 },
                 [PSObject]@{
-                    Name = "Microsoft Visual C++ 2017 x64 Additional Runtime - 14"
-                    SearchType = "Like"
-                    SearchValue = "Microsoft Visual C++ 2017 x64 Additional Runtime - 14.*"
+                    Name = "Microsoft Visual C++ 2017 Redistributable (x64)"
+                    SearchType = "BundleUpgradeCode"
+                    SearchValue = "{C146EF48-4D31-3C3D-A2C5-1E91AF8A0A9B}"
+                    MinimumRequiredVersion = "14.13.26020.0"
                 }
             )
         }
@@ -913,10 +910,43 @@ function Test-SPDscPrereqInstallStatus
                                             "on this system")
                 }
             }
+            "BundleUpgradeCode"
+            {
+                $installedItem = $InstalledItems | Where-Object -FilterScript {
+                    $null -ne $_.BundleUpgradeCode -and (($_.BundleUpgradeCode.Trim() | Compare-Object $itemToCheck.SearchValue) -eq $null)
+                }
+                if ($null -eq $installedItem)
+                {
+                    $itemsInstalled = $false
+                    Write-Verbose -Message ("Prerequisite $($itemToCheck.Name) was not found " + `
+                                            "on this system")
+                }
+                else
+                {
+                    $isRequiredVersionInstalled = $true;
+
+                    [int[]]$minimumRequiredVersion = $itemToCheck.MinimumRequiredVersion.Split('.')
+                    [int[]]$installedVersion = $installedItem.DisplayVersion.Split('.')
+                    for ([int]$index = 0 ; $index -lt $minimumRequiredVersion.Length -and $index -lt $installedVersion.Length; $index++)
+                    {
+                        if($minimumRequiredVersion[$index] -gt $installedVersion[$index])
+                        {
+                            $isRequiredVersionInstalled = $false;
+                        }
+                    }
+                    if ($installedVersion.Length -eq 0 -or -not $isRequiredVersionInstalled)
+                    {
+                        $itemsInstalled = $false
+                        Write-Verbose -Message ("Prerequisite $($itemToCheck.Name) was found but had " + `
+                                                "unexpected version. Expected minimum version $($itemToCheck.MinimumVersion) " + `
+                                                "but found version $($installedItem.DisplayVersion).")
+                    }
+                }
+            }
             Default
             {
                 throw ("Unable to search for a prereq with mode '$($itemToCheck.SearchType)'. " + `
-                       "please use either 'Equals', 'Like' or 'Match'")
+                       "please use either 'Equals', 'Like' or 'Match', or 'BundleUpgradeCode'")
             }
         }
     }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -927,7 +927,7 @@ function Test-SPDscPrereqInstallStatus
 
                     [int[]]$minimumRequiredVersion = $itemToCheck.MinimumRequiredVersion.Split('.')
                     [int[]]$installedVersion = $installedItem.DisplayVersion.Split('.')
-                    for ([int]$index = 0 ; $index -lt $minimumRequiredVersion.Length -and $index -lt $installedVersion.Length; $index++)
+                    for ([int]$index = 0; $index -lt $minimumRequiredVersion.Length -and $index -lt $installedVersion.Length; $index++)
                     {
                         if($minimumRequiredVersion[$index] -gt $installedVersion[$index])
                         {


### PR DESCRIPTION
#### Pull Request (PR) description
Added support for detecting updated installation of Microsoft Visual C++ 2015/2017 Redistributable (x64) for SharePoint 2016 and SharePoint 2019.
Changed required version of Microsoft Visual C++ 2017 Redistributable (x64) to 14.13.26020.0 as this is the version included in the prerequisite installer.

#### This Pull Request (PR) fixes the following issues
- Fixes #959  

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/964)
<!-- Reviewable:end -->
