### PR TITLE
SPDistributedCacheService: Stop-SPServiceInstance may throw an exception in SharePoint 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   * Updated resource to allow localized permission levels
 * SPSite
   * Improved logging
+* SPDistributedCacheService
+  * Fixed exception on Stop-SPServiceInstance with SharePoint 2019
 
 ## v3.1
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
@@ -246,9 +246,17 @@ function Set-TargetResource
 
                 Add-SPDistributedCacheServiceInstance
 
-                Get-SPServiceInstance | Where-Object -FilterScript {
-                    $_.GetType().Name -eq "SPDistributedCacheServiceInstance"
-                } | Stop-SPServiceInstance -Confirm:$false
+                try
+                {
+                    Get-SPServiceInstance | Where-Object -FilterScript {
+                        $_.GetType().Name -eq "SPDistributedCacheServiceInstance"
+                    } | Stop-SPServiceInstance -Confirm:$false
+                }
+                catch
+                {
+                    # In SharePoint 2019, Stop-SPServiceInstance throws an exception if service
+                    # is not running on the server, try/catch handles this scenario
+                }
 
                 $count = 0
                 $maxCount = 30

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPDistributedCacheService/MSFT_SPDistributedCacheService.psm1
@@ -317,7 +317,14 @@ function Set-TargetResource
                     $account = Get-SPManagedAccount -Identity $params.ServiceAccount
                     $cacheService.ProcessIdentity.ManagedAccount = $account
                     $cacheService.ProcessIdentity.Update()
-                    $cacheService.ProcessIdentity.Deploy()
+                    try
+                    {
+                        $cacheService.ProcessIdentity.Deploy()
+                    }
+                    catch
+                    {
+                        # In SharePoint 2019, ProcessIdentity.Deploy() may throw an exception
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR updates resource SPDistributedCacheService to avoid exception on Stop-SPServiceInstance with SharePoint 2019.

#### This Pull Request (PR) fixes the following issues

- https://github.com/PowerShell/SharePointDsc/issues/995: Resource SPDistributedCacheService throws an error when it configures the service for the 1st time. If I run the DSC configuration again on the server there is no error.

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/997)
<!-- Reviewable:end -->
