### PR TITLE
Added -All switch to resolve ""Unable to locate service application" in SP2013

### DIFF
--- a/Modules/SharePointDsc/DSCResources/MSFT_SPServiceInstance/MSFT_SPServiceInstance.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPServiceInstance/MSFT_SPServiceInstance.psm1
@@ -30,7 +30,7 @@ function Get-TargetResource
         $params = $args[0]
         $newName = $args[1]
         
-        $si = Get-SPServiceInstance -Server $env:COMPUTERNAME | Where-Object -FilterScript {
+        $si = Get-SPServiceInstance -Server $env:COMPUTERNAME -All | Where-Object -FilterScript {
             $_.TypeName -eq $params.Name -or `
             $_.TypeName -eq $newName -or `
             $_.GetType().Name -eq $newName
@@ -40,7 +40,7 @@ function Get-TargetResource
         {
             $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
             $fqdn = "$($env:COMPUTERNAME).$domain"
-            $si = Get-SPServiceInstance -Server $fqdn | Where-Object -FilterScript {
+            $si = Get-SPServiceInstance -Server $fqdn -All | Where-Object -FilterScript {
                 $_.TypeName -eq $params.Name -or `
                 $_.TypeName -eq $newName -or `
                 $_.GetType().Name -eq $newName
@@ -108,7 +108,7 @@ function Set-TargetResource
             $params = $args[0]
             $newName = $args[1]
             
-            $si = Get-SPServiceInstance -Server $env:COMPUTERNAME | Where-Object -FilterScript {
+            $si = Get-SPServiceInstance -Server $env:COMPUTERNAME -All | Where-Object -FilterScript {
                 $_.TypeName -eq $params.Name -or `
                 $_.TypeName -eq $newName -or `
                 $_.GetType().Name -eq $newName
@@ -118,7 +118,7 @@ function Set-TargetResource
             {
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $fqdn = "$($env:COMPUTERNAME).$domain"
-                $si = Get-SPServiceInstance -Server $fqdn | Where-Object -FilterScript {
+                $si = Get-SPServiceInstance -Server $fqdn -All | Where-Object -FilterScript {
                     $_.TypeName -eq $params.Name -or `
                     $_.TypeName -eq $newName -or `
                     $_.GetType().Name -eq $newName
@@ -126,7 +126,7 @@ function Set-TargetResource
             }
             if ($null -eq $si)
             {
-                throw [Exception] "Unable to locate service application '$($params.Name)'"
+                throw [Exception] "Unable to locate service instance '$($params.Name)'"
             }
             Start-SPServiceInstance -Identity $si 
         }
@@ -139,7 +139,7 @@ function Set-TargetResource
             $params = $args[0]
             $newName = $args[1]
             
-            $si = Get-SPServiceInstance -Server $env:COMPUTERNAME | Where-Object -FilterScript {
+            $si = Get-SPServiceInstance -Server $env:COMPUTERNAME -All | Where-Object -FilterScript {
                 $_.TypeName -eq $params.Name -or `
                 $_.TypeName -eq $newName -or `
                 $_.GetType().Name -eq $newName
@@ -149,7 +149,7 @@ function Set-TargetResource
             {
                 $domain = (Get-CimInstance -ClassName Win32_ComputerSystem).Domain
                 $fqdn = "$($env:COMPUTERNAME).$domain"
-                $si = Get-SPServiceInstance -Server $fqdn | Where-Object -FilterScript {
+                $si = Get-SPServiceInstance -Server $fqdn -All | Where-Object -FilterScript {
                     $_.TypeName -eq $params.Name -or `
                     $_.TypeName -eq $newName -or `
                     $_.GetType().Name -eq $newName
@@ -157,7 +157,7 @@ function Set-TargetResource
             }
             if ($null -eq $si)
             {
-                throw [Exception] "Unable to locate service application '$($params.Name)'"
+                throw [Exception] "Unable to locate service instance '$($params.Name)'"
             }
             Stop-SPServiceInstance -Identity $si
         }


### PR DESCRIPTION
Also updated wording of error message to ""Unable to locate service application" to be more accurate.

#### Pull Request (PR) description
MSFT_SPServiceInstance: No longer gives errors about "missing service application" in SharePoint 2013


#### This Pull Request (PR) fixes the following issues
In SharePoint 2013, trying to get a service instance without using the -All parameter would fail. This change adds the parameter where needed.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
