### PR TITLE
SPUserProfileSyncConnection: Fixes for SP2016 environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@
   * Added -All switch to resolve "Unable to locate service application" in SP2013
 * SPUserProfileProperty
   * Fix user profile property mappings does not work
+* SPUserProfileSyncConnection
+  * Fixed issue where test resource never would return true for any configurations
+    on SharePoint 2016/2019
+  * Fixed issue where updating existing connection never would work for any
+    configurations on SharePoint 2016/2019
+  * Updated documentation to reflect that Fore will not impact configurations for
+    SharePoint 2016/2019. Updated the test method accordingly.
 * SPUserProfileSyncService
   * Fixed issue where failure to configure the sync service would not throw error
 * SPWebAppPolicy

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.psm1
@@ -161,10 +161,10 @@ function Get-TargetResource
                 return @{
                     Name = $params.Name
                     UserProfileService = $params.UserProfileService
-                    Forest = $namingContexts.DistinguishedName
+                    Forest = $namingContexts.DistinguishedName.Replace(",DC=", ".").Replace("DC=", "");
                     ConnectionCredentials = $accountCredentials
-                    IncludedOUs = ,$inclOUs
-                    ExcludedOUs = ,$exclOUs
+                    IncludedOUs = $inclOUs
+                    ExcludedOUs = $exclOUs
                     Server = $null
                     Port = $params.Port
                     UseSSL = $useSSL
@@ -201,8 +201,8 @@ function Get-TargetResource
                 Forest = $connection.Server
                 Name = $params.Name
                 ConnectionCredentials = $accountCredentials
-                IncludedOUs = ,$inclOUs
-                ExcludedOUs = ,$exclOUs
+                IncludedOUs = $inclOUs
+                ExcludedOUs = $exclOUs
                 Server = $domainController
                 UseSSL = $connection.UseSSL
                 UseDisabledFilter = $connection.UseDisabledFilter
@@ -405,63 +405,6 @@ function Set-TargetResource
             else
             {
                 Write-Verbose -Message "Creating a new connection "
-                if ($null -ne $connection -and $params.Forest -ine  $connection.Server)
-                {
-                    if ($params.ContainsKey("Force") -and $params.Force -eq $true)
-                    {
-                        Write-Verbose -Message "Force specified, deleting already existing connection"
-                        $connection.Delete()
-                    }
-                    else
-                    {
-                        throw "connection exists and forest is different. use force"
-                    }
-
-                }
-
-                $servers = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
-                if ($params.ContainsKey("Server"))
-                {
-                    $servers.add($params.Server)
-                }
-                $listIncludedOUs = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
-                $params.IncludedOUs | ForEach-Object -Process {
-                    $listIncludedOUs.Add($_)
-                }
-
-                $listExcludedOUs = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
-                if ($params.ContainsKey("ExcludedOus"))
-                {
-                    $params.ExcludedOus | ForEach-Object -Process {
-                        $listExcludedOUs.Add($_)
-                    }
-                }
-                $list = New-Object -TypeName System.Collections.Generic.List[[Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext]]
-
-                $partition = Get-SPDSCADSIObject -LdapPath ("LDAP://" +("DC=" + $params.Forest.Replace(".", ",DC=")))
-                $list.Add((New-Object -TypeName "Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext" `
-                                    -ArgumentList @(
-                                                $partition.distinguishedName,
-                                                $params.Forest,
-                                                $false,
-                                                (New-Object -TypeName "System.Guid" `
-                                                            -ArgumentList $partition.objectGUID),
-                                                $listIncludedOUs,
-                                                $listExcludedOUs,
-                                                $null ,
-                                                $false)))
-                $partition = Get-SPDSCADSIObject -LdapPath ("LDAP://CN=Configuration," + ("DC=" + $params.Forest.Replace(".", ",DC=")))
-                $list.Add((New-Object -TypeName "Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext" `
-                                    -ArgumentList @(
-                                                $partition.distinguishedName,
-                                                $params.Forest,
-                                                $true,
-                                                (New-Object -TypeName "System.Guid" `
-                                                            -ArgumentList $partition.objectGUID),
-                                                $listIncludedOUs ,
-                                                $listExcludedOUs ,
-                                                $null ,
-                                                $false)))
 
                 $userDomain = $params.ConnectionCredentials.UserName.Split("\")[0]
                 $userName= $params.ConnectionCredentials.UserName.Split("\")[1]
@@ -472,6 +415,64 @@ function Set-TargetResource
                 {
                     15
                     {
+                        if ($null -ne $connection -and $params.Forest -ine  $connection.Server)
+                        {
+                            if ($params.ContainsKey("Force") -and $params.Force -eq $true)
+                            {
+                                Write-Verbose -Message "Force specified, deleting already existing connection"
+                                $connection.Delete()
+                            }
+                            else
+                            {
+                                throw "connection exists and forest is different. use force"
+                            }
+                        }
+
+                        $servers = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
+                        if ($params.ContainsKey("Server"))
+                        {
+                            $servers.add($params.Server)
+                        }
+                        $listIncludedOUs = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
+                        $params.IncludedOUs | ForEach-Object -Process {
+                            $listIncludedOUs.Add($_)
+                        }
+
+                        $listExcludedOUs = New-Object -TypeName "System.Collections.Generic.List[[System.String]]"
+                        if ($params.ContainsKey("ExcludedOus"))
+                        {
+                            $params.ExcludedOus | ForEach-Object -Process {
+                                $listExcludedOUs.Add($_)
+                            }
+                        }
+
+                        $list = New-Object -TypeName System.Collections.Generic.List[[Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext]]
+
+                        $partition = Get-SPDSCADSIObject -LdapPath ("LDAP://" +("DC=" + $params.Forest.Replace(".", ",DC=")))
+                        $list.Add((New-Object -TypeName "Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext" `
+                                            -ArgumentList @(
+                                                        $partition.distinguishedName,
+                                                        $params.Forest,
+                                                        $false,
+                                                        (New-Object -TypeName "System.Guid" `
+                                                                    -ArgumentList $partition.objectGUID),
+                                                        $listIncludedOUs,
+                                                        $listExcludedOUs,
+                                                        $null ,
+                                                        $false)))
+                        $partition = Get-SPDSCADSIObject -LdapPath ("LDAP://CN=Configuration," + ("DC=" + $params.Forest.Replace(".", ",DC=")))
+                        $list.Add((New-Object -TypeName "Microsoft.Office.Server.UserProfiles.DirectoryServiceNamingContext" `
+                                            -ArgumentList @(
+                                                        $partition.distinguishedName,
+                                                        $params.Forest,
+                                                        $true,
+                                                        (New-Object -TypeName "System.Guid" `
+                                                                    -ArgumentList $partition.objectGUID),
+                                                        $listIncludedOUs ,
+                                                        $listExcludedOUs ,
+                                                        $null ,
+                                                        $false)))
+
                         Write-Verbose -Message "Creating the new connection via object model (SP2013)"
                         $upcm.ConnectionManager.AddActiveDirectoryConnection( [Microsoft.Office.Server.UserProfiles.ConnectionType]::ActiveDirectory,  `
                                                 $params.Name, `
@@ -602,20 +603,27 @@ function Test-TargetResource
         return $false
     }
 
-    if ($Force -eq $true)
+    $installedVersion = Get-SPDSCInstalledProductVersion
+    $valuesToCheck = @("Forest",
+    "UserProfileService",
+    "Server",
+    "UseSSL",
+    "IncludedOUs",
+    "Ensure")
+
+    if($installedVersion.FileMajorPart -eq 15)
     {
-        return $false
+        if ($Force -eq $true)
+        {
+            return $false
+        }
+
+        $valuesToCheck += "ExcludedOUs"
     }
 
     return Test-SPDscParameterState -CurrentValues $CurrentValues `
                                     -DesiredValues $PSBoundParameters `
-                                    -ValuesToCheck @("Forest",
-                                                     "UserProfileService",
-                                                     "Server",
-                                                     "UseSSL",
-                                                     "IncludedOUs",
-                                                     "ExcludedOUs",
-                                                     "Ensure")
+                                    -ValuesToCheck $valuesToCheck
 }
 
 <#

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/MSFT_SPUserProfileSyncConnection.schema.mof
@@ -5,13 +5,13 @@ class MSFT_SPUserProfileSyncConnection : OMI_BaseResource
     [Required, Description("The name of the AD forest to read from")] string Forest;
     [Required, Description("The name of the user profile service that this connection is attached to")] string UserProfileService;
     [Required, Description("The credentials to connect to Active Directory with"), EmbeddedInstance("MSFT_Credential")] string ConnectionCredentials;
-    [Required, Description("A list of the OUs to import users from")] string IncludedOUs[];
-    [Write, Description("A list of the OUs to ignore users from")] string ExcludedOUs[];
+    [Required, Description("A list of the OUs to import users from. For SharePoint 2016/2019 existing OUs will not be removed if not included in this list. Use ExludedOUs for removing OUs in SharePoint 2016/2019")] string IncludedOUs[];
+    [Write, Description("A list of the OUs to ignore users from. For SharePoint 2016/2019 matching existing OUs to include are removed.")] string ExcludedOUs[];
     [Write, Description("The specific AD server to connect to")] string Server;
     [Write, Description("The specific port to connect to")] uint32 Port;
     [Write, Description("Should SSL be used for the connection")] boolean UseSSL;
     [Write, Description("Should disabled accounts be filtered")] boolean UseDisabledFilter;
-    [Write, Description("Set to true to run the set method on every call to this resource")] boolean Force;
+    [Write, Description("Set to true to run the set method on every call to this resource. Only has effect on SharePoint 2013")] boolean Force;
     [Write, Description("The type of the connection - currently only Active Directory is supported"), ValueMap{"ActiveDirectory","BusinessDataCatalog"}, Values{"ActiveDirectory","BusinessDataCatalog"}] string ConnectionType;
     [Write, Description("Present if the connection should exist, absent if it should not"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] string InstallAccount;

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPUserProfileSyncConnection/readme.md
@@ -7,3 +7,10 @@ This resource will ensure a specifc user profile sync connection
 is in place and that it is configured accordingly to its definition
 
 This resource currently supports AD only.
+
+Force only works with SharePoint 2013. For SharePoint 2016/2019
+the resource is not able to remove existing OUs.
+You will have to use the ExcludedOUs for this. This means you need
+to know which OUs to remove. If any extra OUs exists after the
+configuration has run the test method will report the resource not
+in desired state.

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileSyncConnection.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPUserProfileSyncConnection.Tests.ps1
@@ -27,10 +27,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         if ($Global:SPDscHelper.CurrentStubBuildNumber.Major -eq 16)
         {
             $name = "contoso-com"
+            $defaultDistinguishedName = "DC=litware,DC=net"
         }
         else
         {
             $name = "contoso"
+            $defaultDistinguishedName = "litware.net"
         }
 
         try { [Microsoft.Office.Server.UserProfiles] }
@@ -422,10 +424,15 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 Test-TargetResource @testParams | Should Be $false
             }
 
-            It "Should throw exception as force isn't specified" {
-                $Global:SPDscUPSSyncConnectionDeleteCalled=$false
-                {Set-TargetResource @testParams} | should throw
-                $Global:SPDscUPSSyncConnectionDeleteCalled | Should be $false
+            switch ($Global:SPDscHelper.CurrentStubBuildNumber.Major)
+            {
+                15 {
+                    It "Should throw exception as force isn't specified" {
+                        $Global:SPDscUPSSyncConnectionDeleteCalled=$false
+                        {Set-TargetResource @testParams} | should throw
+                        $Global:SPDscUPSSyncConnectionDeleteCalled | Should be $false
+                    }
+                }
             }
 
             $forceTestParams = @{
@@ -440,12 +447,17 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 ConnectionType = "ActiveDirectory"
             }
 
-            It "delete and create as force is specified" {
-                $Global:SPDscUPSSyncConnectionDeleteCalled=$false
-                $Global:SPDscUPSAddActiveDirectoryConnectionCalled =$false
-                Set-TargetResource @forceTestParams
-                $Global:SPDscUPSSyncConnectionDeleteCalled | Should be $true
-                $Global:SPDscUPSAddActiveDirectoryConnectionCalled | Should be $true
+            switch ($Global:SPDscHelper.CurrentStubBuildNumber.Major)
+            {
+                15 {
+                    It "delete and create as force is specified" {
+                        $Global:SPDscUPSSyncConnectionDeleteCalled=$false
+                        $Global:SPDscUPSAddActiveDirectoryConnectionCalled =$false
+                        Set-TargetResource @forceTestParams
+                        $Global:SPDscUPSSyncConnectionDeleteCalled | Should be $true
+                        $Global:SPDscUPSAddActiveDirectoryConnectionCalled | Should be $true
+                    }
+                }
             }
 
             It "returns false in Test method as force is specified" {
@@ -589,6 +601,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 Type= "ActiveDirectory"
             }
 
+            $namingContext =@{
+                DistinguishedName = $defaultDistinguishedName
+            }
+
+            $litWareconnection.NamingContexts.Add($namingContext);
+
             $userProfileServiceValidConnection =  @{
                 Name = "User Profile Service Application"
                 TypeName = "User Profile Service Application"
@@ -687,6 +705,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                 }
             }
 
+            $namingContext =@{
+                DistinguishedName = $defaultDistinguishedName
+            }
+
+            $litWareconnection.NamingContexts.Add($namingContext);
+
             $litWareconnection = $litWareconnection | Add-Member -MemberType ScriptMethod `
                                                                  -Name Delete `
                                                                  -Value {
@@ -779,6 +803,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                     Type= "ActiveDirectory"
                 }
 
+                $namingContext =@{
+                    DistinguishedName = "DC=LITWARE,DC=NET"
+                }
+
+                $litWareconnection.NamingContexts.Add($namingContext);
+
                 $userProfileServiceValidConnection =  @{
                     Name = "User Profile Service Application"
                     TypeName = "User Profile Service Application"
@@ -852,6 +882,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
                     UseDisabledFilter = $false
                     Type= "ActiveDirectory"
                 }
+
+                $namingContext =@{
+                    DistinguishedName = "DC=LITWARE,DC=NET"
+                }
+
+                $litWareconnection.NamingContexts.Add($namingContext);
 
                 $userProfileServiceValidConnection =  @{
                     Name = "User Profile Service Application"


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed issue where test resource never would return true for any configurations on SharePoint 2016/2019
Fixed issue where updating existing connection never would work for any configurations on SharePoint 2016/2019
Updated documentation to reflect that Force will not impact configurations for SharePoint 2016/2019. Updated the test method accordingly.

#### This Pull Request (PR) fixes the following issues
Partially fixes #1021 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1017)
<!-- Reviewable:end -->
