### PR TITLE
SPWebAppPeoplePickerSettings: Converted access account password to secure string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   * Fix user profile property mappings does not work
 * SPUserProfileSyncService
   * Fixed issue where failure to configure the sync service would not throw error
+* SPWebAppPeoplePickerSettings
+  * Converted password for access account to secure string. Previsouly
+    the resource would fail setting the password and an exeption was thrown that
+    printed the password in clear text.
 * SPWebAppPolicy
   * Fixed issue where parameter MembersToExclude did not work as expected
 * SPWorkflowService

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
@@ -183,16 +183,20 @@ function Set-TargetResource
                     }
 
                     $adsearchobj.IsForest = $searchADDomain.IsForest
-                    $adsearchobj.LoginName = $searchADDomain.AccessAccount.UserName
 
-                    if([string]::IsNullOrEmpty($searchADDomain.AccessAccount.Password))
+                    if ($null -ne $searchADDomain.AccessAccount)
                     {
-                        $adsearchobj.SetPassword($null)
-                    }
-                    else
-                    {
-                        $accessAccountPassword = ConvertTo-SecureString $searchADDomain.AccessAccount.Password -AsPlainText -Force
-                        $adsearchobj.SetPassword($accessAccountPassword)
+                        $adsearchobj.LoginName = $searchADDomain.AccessAccount.UserName
+
+                        if([string]::IsNullOrEmpty($searchADDomain.AccessAccount.Password))
+                        {
+                            $adsearchobj.SetPassword($null)
+                        }
+                        else
+                        {
+                            $accessAccountPassword = ConvertTo-SecureString $searchADDomain.AccessAccount.Password -AsPlainText -Force
+                            $adsearchobj.SetPassword($accessAccountPassword)
+                        }
                     }
 
                     $wa.PeoplePickerSettings.SearchActiveDirectoryDomains.Add($adsearchobj)

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
@@ -79,6 +79,7 @@ function Get-TargetResource
 
 function Set-TargetResource
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification  =  "Ignoring this because the used AccessAccount does not use SecureString to handle the password")]
     [CmdletBinding()]
     param
     (

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
@@ -189,7 +189,7 @@ function Set-TargetResource
                     if ($null -ne $prop)
                     {
                         $adsearchobj.LoginName = $searchADDomain.AccessAccount.UserName
-                        $adsearchobj.SetPassword($searchADDomain.AccessAccount.Password)
+                        $adsearchobj.SetPassword($(ConvertTo-SecureString $searchADDomain.AccessAccount.Password -AsPlainText -Force))
                     }
                     $wa.PeoplePickerSettings.SearchActiveDirectoryDomains.Add($adsearchobj)
                 }

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPWebAppPeoplePickerSettings/MSFT_SPWebAppPeoplePickerSettings.psm1
@@ -182,15 +182,18 @@ function Set-TargetResource
                     }
 
                     $adsearchobj.IsForest = $searchADDomain.IsForest
+                    $adsearchobj.LoginName = $searchADDomain.AccessAccount.UserName
 
-                    $prop = $searchADDomain.CimInstanceProperties | Where-Object -FilterScript {
-                        $_.Name -eq "AccessAccount"
-                    }
-                    if ($null -ne $prop)
+                    if([string]::IsNullOrEmpty($searchADDomain.AccessAccount.Password))
                     {
-                        $adsearchobj.LoginName = $searchADDomain.AccessAccount.UserName
-                        $adsearchobj.SetPassword($(ConvertTo-SecureString $searchADDomain.AccessAccount.Password -AsPlainText -Force))
+                        $adsearchobj.SetPassword($null)
                     }
+                    else
+                    {
+                        $accessAccountPassword = ConvertTo-SecureString $searchADDomain.AccessAccount.Password -AsPlainText -Force
+                        $adsearchobj.SetPassword($accessAccountPassword)
+                    }
+
                     $wa.PeoplePickerSettings.SearchActiveDirectoryDomains.Add($adsearchobj)
                 }
             }

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPWebAppPeoplePickerSettings.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPWebAppPeoplePickerSettings.Tests.ps1
@@ -78,7 +78,7 @@ namespace Microsoft.SharePoint.Administration {
                         AccessAccount  = (New-CimInstance -ClassName MSFT_Credential `
                                                     -Property @{
                                                         Username=[string]$mockAccount.UserName;
-                                                        Password=[string]$null
+                                                        Password=[string]$mockAccount.Password;
                                                     } `
                                                     -Namespace root/microsoft/windows/desiredstateconfiguration `
                                                     -ClientOnly)
@@ -199,7 +199,7 @@ namespace Microsoft.SharePoint.Administration {
                         AccessAccount  = (New-CimInstance -ClassName MSFT_Credential `
                                                     -Property @{
                                                         Username=[string]$mockAccount.UserName;
-                                                        Password=[string]$null
+                                                        Password=[string]$mockAccount.Password;
                                                     } `
                                                     -Namespace root/microsoft/windows/desiredstateconfiguration `
                                                     -ClientOnly)


### PR DESCRIPTION
#### Pull Request (PR) description
Converted password for access account to secure string. Previsouly the resource would fail setting the password and an exeption was thrown that printed the password in clear text.
I would expect the password to already be a secure string, but apparently that's not the case.

#### This Pull Request (PR) fixes the following issues
- Fixes #1019 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1018)
<!-- Reviewable:end -->
