### PR TITLE
Patch invoke sp dsc command memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for SharePointDsc
 
 ## Unreleased
+
 * Invoke-SPDSCCommand in SharePointDsc.Util module
   * Fixed issue where powershell session was never removed and may lead to memory leak
 * SPConfigWizard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log for SharePointDsc
 
 ## Unreleased
-
+* Invoke-SPDSCCommand in SharePointDsc.Util module
+  * Fixed issue where powershell session was never removed and may lead to memory leak
 * SPConfigWizard
   * Improved logging
 * SPFarm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 * SharePointDsc generic
   * Implemented workaround for PSSA v1.18 issue. No further impact for
     the rest of the resources
->>>>>>> dev
 * SPConfigWizard
   * Improved logging
 * SPFarm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Invoke-SPDSCCommand in SharePointDsc.Util module
-  * Fixed issue where powershell session was never removed and may lead to memory leak
+  * Fixed issue where powershell session was never removed and 
+    may lead to memory leak
 * SPConfigWizard
   * Improved logging
 * SPFarm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Invoke-SPDSCCommand in SharePointDsc.Util module
-  * Fixed issue where powershell session was never removed and 
+  * Fixed issue where powershell session was never removed and
     may lead to memory leak
 * SPConfigWizard
   * Improved logging

--- a/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -426,7 +426,7 @@ function Invoke-SPDSCCommand
 
         # Running garbage collection to resolve issues related to Azure DSC extention use
         [GC]::Collect()
-
+        $result = $null
         $session = New-PSSession -ComputerName $env:COMPUTERNAME `
                                  -Credential $Credential `
                                  -Authentication CredSSP `

--- a/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -442,7 +442,7 @@ function Invoke-SPDSCCommand
 
         try
         {
-            return Invoke-Command @invokeArgs -Verbose
+            $result = Invoke-Command @invokeArgs -Verbose
         }
         catch
         {
@@ -454,6 +454,10 @@ function Invoke-SPDSCCommand
             }
             else
             {
+                if ($session)
+                {
+                    Remove-PSSession -Session $session
+                }                
                 throw $_
             }
         }
@@ -462,6 +466,7 @@ function Invoke-SPDSCCommand
         {
             Remove-PSSession -Session $session
         }
+        return $result
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Corrected the issue in order to remove-pssession and avoid memory leak from the Invoke-SPDSCCommand function in SharePointDsc.Util.psm1

#### This Pull Request (PR) fixes the following issues
Fixes #1037
#### Task list
- [x ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1038)
<!-- Reviewable:end -->
