### PR TITLE
Modules\SharePointDsc.Util: Bugfix Invoke-SPDSCCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * SharePointDsc generic
   * Implemented workaround for PSSA v1.18 issue. No further impact for
     the rest of the resources
+  * Fixed issue where powershell session was never removed and leaded to
+    memory leak
 * SPConfigWizard
   * Improved logging
 * SPFarm

--- a/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
+++ b/Modules/SharePointDsc/Modules/SharePointDsc.Util/SharePointDsc.Util.psm1
@@ -457,10 +457,12 @@ function Invoke-SPDSCCommand
                 throw $_
             }
         }
-
-        if ($session)
+        finally
         {
-            Remove-PSSession -Session $session
+            if ($session)
+            {
+                Remove-PSSession -Session $session
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

I added a finally statement for the removal of the created session. Since in the Try section the value of the command is preceded by a return statement, the removal of the session is never executed when the command succeed.

#### This Pull Request (PR) fixes the following issues

Invoke-SPDSCCommand in SharePointDsc.Util.psm1 memory leak #1037

#### Task list

Not applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1042)
<!-- Reviewable:end -->
