### PR TITLE
Fixed issue 1087 + vscode launch settings

### DIFF
--- a/.vscode/GetTestCoverage.ps1
+++ b/.vscode/GetTestCoverage.ps1
@@ -1,0 +1,32 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $UnitTestFilePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $SharePointCmdletModule = (Join-Path -Path $PSScriptRoot `
+            -ChildPath "..\Stubs\SharePoint\15.0.4805.1000\Microsoft.SharePoint.PowerShell.psm1" `
+            -Resolve)
+)
+
+if ($UnitTestFilePath.EndsWith("Tests.ps1"))
+{
+
+    $pesterParameters = @{
+        Path       = $unitTestFilePath
+        Parameters = @{
+            SharePointCmdletModule = $SharePointCmdletModule
+        }
+    }
+
+    $unitTest = Get-Item -Path $UnitTestFilePath
+    $unitTestName = "$($unitTest.Name.Split('.')[1])"
+
+    $unitTestFilePath = (Join-Path -Path $PSScriptRoot `
+            -ChildPath "..\Modules\SharePointDsc\DSCResources\MSFT_$($unitTestName)\MSFT_$($unitTestName).psm1" `
+            -Resolve)
+
+    Invoke-Pester -Script $pesterParameters -CodeCoverage $UnitTestFilePath -Verbose
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,39 @@
             "createTemporaryIntegratedConsole": true
         },
         {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Get current unit test code overage (SP2013)",
+            "script": "${workspaceRoot}/.vscode/GetTestCoverage.ps1",
+            "args": [
+                "${file}",
+                "${workspaceRoot}/Tests/Unit/Stubs/SharePoint/15.0.4805.1000/Microsoft.SharePoint.PowerShell.psm1"
+            ],
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Get current unit test code overage (SP2016)",
+            "script": "${workspaceRoot}/.vscode/GetTestCoverage.ps1",
+            "args": [
+                "${file}",
+                "${workspaceRoot}/Tests/Unit/Stubs/SharePoint/16.0.4456.1000/Microsoft.SharePoint.PowerShell.psm1"
+            ],
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "Get current unit test code overage (SP2019)",
+            "script": "${workspaceRoot}/.vscode/GetTestCoverage.ps1",
+            "args": [
+                "${file}",
+                "${workspaceRoot}/Tests/Unit/Stubs/SharePoint/16.0.10337.12109/Microsoft.SharePoint.PowerShell.psm1"
+            ],
+            "createTemporaryIntegratedConsole": true
+        },
+        {
             "name": "Debug current file",
             "type": "PowerShell",
             "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* SharePointDsc generic
+  * Added new launch actions to vscode to allow code coverage reports for
+    the current unit test file.
+* SPProductUpdate
+  * Fixes an issue using ShutdownServices when no Farm is available.
 * SPTrustedRootAuthority
   * Fixes issue where Set method throws an error because the
     parameter CertificateFilePath is not read correctly.

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
@@ -391,7 +391,19 @@ function Set-TargetResource
 
     $installedVersion = Get-SPDscInstalledProductVersion
 
-    if ($ShutdownServices)
+    Write-Verbose -Message "Try to load local Farm"
+
+    $farmIsAvailable = Invoke-SPDscCommand -Credential $InstallAccount `
+        -ScriptBlock {
+        $farm = Get-SPFarm -ErrorAction SilentlyContinue
+        if ($null -eq $farm)
+        {
+            return $false
+        }
+        return $true
+    }
+
+    if ($ShutdownServices -and $farmIsAvailable)
     {
         Write-Verbose -Message "Stopping services to speed up installation process"
 
@@ -527,7 +539,7 @@ function Set-TargetResource
         }
     }
 
-    if ($ShutdownServices)
+    if ($ShutdownServices -and $farmIsAvailable)
     {
         Write-Verbose -Message "Restart stopped services"
         Set-Service -Name "SPTimerV4" -StartupType Automatic

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPProductUpdate.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPProductUpdate.Tests.ps1
@@ -90,6 +90,11 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             return $true
         }
 
+        # Additional mock needed for fixing #1087
+        Mock -CommandName Get-SPFarm {
+            return $true
+        }
+
         Mock -CommandName Get-Service -MockWith {
             $service = @{
                 Status = "Running"
@@ -247,6 +252,10 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             Add-TestRegistryData -PatchLevel "RTM"
 
+            Mock -CommandName Get-SPFarm {
+                return $null
+            }
+
             Mock -CommandName Get-ItemProperty -MockWith {
                 if ($Global:SPDscHelper.CurrentStubBuildNumber.Major -eq 15)
                 {
@@ -295,6 +304,8 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             It "Should run the Start-Process function in the set method" {
                 Set-TargetResource @testParams
+                # MockCalled set to 0, as there is no farm available.
+                Assert-MockCalled Get-Service -Exactly 0
                 Assert-MockCalled Start-Process
             }
 
@@ -677,6 +688,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
             It "Should run the Start-Process function in the set method" {
                 Set-TargetResource @testParams
+                Assert-MockCalled Get-Service -Exactly 6
                 Assert-MockCalled Start-Process
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Added fixes for 1087.
New vscode launch settings to get code coverage reports for the currently selected unit test.

@ykuijs could you do a integration test of the changes in the SPProductUpdate Resource. I do not have a server which meets the prerequisites right now.

#### This Pull Request (PR) fixes the following issues:

- Fixes #1087 
- Closes #1092 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1091)
<!-- Reviewable:end -->
