### PR TITLE
Fixes PowerShell/SharePointDsc#1109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 * SPWebAppAuthentication
   * Fixes issue where Test method return false on NON-US OS.
+  
+* SPInstall, SPInstallPrereqs, SPInstallLanguagePack, SPProductUpdate
+  * Fixes a terminating error for sources in weird file shares (#1109)
 
 ## v3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@
 * SPFarmSolution
   * Fix for Web Application scoped solutions.
 
+* SPInstall
+  * Fixes a terminating error for sources in weird file shares (#1109)
+  
+* SPInstallLanguagePack
+  * Fixes a terminating error for sources in weird file shares (#1109)
+
+* SPInstallPrereqs
+  * Fixes a terminating error for sources in weird file shares (#1109)
+
+* SPProductUpdate
+  * Fixes a terminating error for sources in weird file shares (#1109)
+
 * SPWebAppAuthentication
   * Fixes issue where Test method return false on NON-US OS.
-  
-* SPInstall, SPInstallPrereqs, SPInstallLanguagePack, SPProductUpdate
-  * Fixes a terminating error for sources in weird file shares (#1109)
 
 ## v3.6
 

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
@@ -74,7 +74,14 @@ function Get-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("Setup file is blocked! Please use 'Unblock-File -Path $InstallerPath' " + `
@@ -245,7 +252,14 @@ function Set-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("Setup file is blocked! Please use 'Unblock-File -Path $InstallerPath' " + `

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstall/MSFT_SPInstall.psm1
@@ -80,7 +80,7 @@ function Get-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {
@@ -258,7 +258,7 @@ function Set-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallLanguagePack/MSFT_SPInstallLanguagePack.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallLanguagePack/MSFT_SPInstallLanguagePack.psm1
@@ -77,7 +77,7 @@ function Get-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {
@@ -324,7 +324,7 @@ function Set-TargetResource
         }
         catch 
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallLanguagePack/MSFT_SPInstallLanguagePack.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallLanguagePack/MSFT_SPInstallLanguagePack.psm1
@@ -71,7 +71,14 @@ function Get-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $setupExe -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $setupExe -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("Setup file is blocked! Please use 'Unblock-File -Path $setupExe' " + `
@@ -311,7 +318,14 @@ function Set-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $setupExe -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $setupExe -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch 
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("Setup file is blocked! Please use 'Unblock-File -Path $setupExe' " + `

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -231,7 +231,14 @@ function Get-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("PrerequisitesInstaller is blocked! Please use 'Unblock-File -Path " + `
@@ -639,7 +646,14 @@ function Set-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        try 
+        {
+            $zone = Get-Item -Path $InstallerPath -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
         if ($null -ne $zone)
         {
             throw ("PrerequisitesInstaller is blocked! Please use 'Unblock-File -Path " + `

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPInstallPrereqs/MSFT_SPInstallPrereqs.psm1
@@ -237,7 +237,7 @@ function Get-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {
@@ -652,7 +652,7 @@ function Set-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
         if ($null -ne $zone)
         {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
@@ -78,7 +78,14 @@ function Get-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $SetupFile -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $SetupFile -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
 
         if ($null -ne $zone)
         {
@@ -306,7 +313,14 @@ function Set-TargetResource
     if ($checkBlockedFile -eq $true)
     {
         Write-Verbose -Message "Checking status now"
-        $zone = Get-Item -Path $SetupFile -Stream "Zone.Identifier" -EA SilentlyContinue
+        try
+        {
+            $zone = Get-Item -Path $SetupFile -Stream "Zone.Identifier" -EA SilentlyContinue
+        }
+        catch
+        {
+            #empty catch-block since we only care about the non-fail case
+        }
 
         if ($null -ne $zone)
         {

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPProductUpdate/MSFT_SPProductUpdate.psm1
@@ -84,7 +84,7 @@ function Get-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
 
         if ($null -ne $zone)
@@ -319,7 +319,7 @@ function Set-TargetResource
         }
         catch
         {
-            #empty catch-block since we only care about the non-fail case
+            Write-Verbose -Message 'Encountered error while reading file stream. Ignoring file stream.'
         }
 
         if ($null -ne $zone)


### PR DESCRIPTION
### Pull Request (PR) description
Added try-catch blocks around Get-Item. A terminating error for sources in weird file shares [particularly VMWare Workstation Shared Folders].
A bit against the guidelines: An empty catch-block because the result is only important if no terminating error happens. The `-ErrorAction SilentlyContinue` existed already for the command, though that doesn't catch terminating errors (as experienced in the linked issue). If the empty catch block really isn't wanted please tell me what to do in it.

#### This Pull Request (PR) fixes the following issues
- Fixes #1109

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1112)
<!-- Reviewable:end -->
