### PR TITLE
Fixed null exception for developer dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Fixed issue with incorrect check for upgrade status of server
 * SPFarm
   * Removed SingleServer as ServerRole, since this is an invalid role.
+  * Fixed error when changing developer dashboard display level.
 * SPFarmSolution
   * Fix for Web Application scoped solutions.
 * SPInstall

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPFarm/MSFT_SPFarm.psm1
@@ -616,7 +616,7 @@ function Set-TargetResource
                 Write-Verbose -Message "Updating Developer Dashboard setting"
                 $admService = Get-SPDscContentService
                 $developerDashboardSettings = $admService.DeveloperDashboardSettings
-                $developerDashboardSettings.DisplayLevel = [Microsoft.SharePoint.Administration.SPDeveloperDashboardLevel]::$params.DeveloperDashboard
+                $developerDashboardSettings.DisplayLevel = [Microsoft.SharePoint.Administration.SPDeveloperDashboardLevel]::$($params.DeveloperDashboard)
                 $developerDashboardSettings.Update()
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed error when setting developer dashboard display level. The error resulted in the following error message:
PowerShell DSC resource MSFT_SPFarm  failed to execute Set-TargetResource functionality with error message: Exception setting "DisplayLevel": "Cannot convert null to type "Microsoft.SharePoint.Administration.SPDeveloperDashboardLevel" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "Off,OnDemand,On"."

#### This Pull Request (PR) fixes the following issues

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1118)
<!-- Reviewable:end -->
