### PR TITLE
Implement fix for MMS Default issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 The following changes will break v3.x and earlier configurations that use these
 resources:
 
+* SPManagedMetaDataServiceAppDefault
+  * Updated resource to allow the configuration of default per service application
+    proxy groups instead of per farm
 * SPSearchServiceApp
   * Removed the WindowsServiceAccount parameter that was depricated in v3.1
 * SPUserProfileServiceApp

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.psm1
@@ -145,25 +145,10 @@ function Set-TargetResource
                 -ErrorAction SilentlyContinue
         }
 
-        if ($null -eq $serviceAppProxyGroup)
-        {
-            throw "Specified ServiceAppProxyGroup $($params.ServiceAppProxyGroup) does not exist."
-        }
-
         $serviceAppProxies = $serviceAppProxyGroup.Proxies
-
-        if ($null -eq $serviceAppProxies)
-        {
-            throw "There are no Service Application Proxies available in the proxy group"
-        }
 
         $serviceAppProxies = $serviceAppProxies | Where-Object -FilterScript {
             $_.GetType().FullName -eq "Microsoft.SharePoint.Taxonomy.MetadataWebServiceApplicationProxy"
-        }
-
-        if ($null -eq $serviceAppProxies)
-        {
-            throw "There are no Managed Metadata Service Application Proxies available in the proxy group"
         }
 
         foreach ($serviceAppProxy in $serviceAppProxies)

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.schema.mof
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/MSFT_SPManagedMetadataServiceAppDefault.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("SPManagedMetaDataServiceAppDefault")]
 class MSFT_SPManagedMetaDataServiceAppDefault : OMI_BaseResource
 {
-    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Key, Description("Specifies the Service Application Proxy Group for which to configure the defaults. Use 'default' or the name of the proxy group.")] String ServiceAppProxyGroup;
     [Required, Description("The name of the managed metadata service application proxy used as default column terms set")] String DefaultSiteCollectionProxyName;
     [Required, Description("The name of the managed metadata service application proxy used as default keyword terms set")] String DefaultKeywordProxyName;
     [Write, Description("POWERSHELL 4 ONLY: The account to run this resource as, use PsDscRunAsCredential if using PowerShell 5"), EmbeddedInstance("MSFT_Credential")] String InstallAccount;

--- a/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
+++ b/Modules/SharePointDsc/DSCResources/MSFT_SPManagedMetadataServiceAppDefault/readme.md
@@ -4,9 +4,10 @@
 **Requires CredSSP:** No
 
 Using several managed metadata service instances in a farm requires some
-configuration, which service application proxy should be used as default
-for keywords or site collection specific term sets.
+configuration. Each Service Application Proxy Group can only have one
+service application proxy configured as default for keywords or site
+collection specific term sets.
 
-This setting has to be configured in conjunction with the SPManagedMetadataServiceApp
-resource. This resource allows to specify which managed metadata service application
-proxy should be used as default for these two settings.
+This resource has to be configured in conjunction with the SPManagedMetadataServiceApp
+resource and allows to specify which managed metadata service application proxy
+should be used as default for the proxy group.

--- a/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
@@ -1,6 +1,7 @@
 <#
 .EXAMPLE
-    This example shows how to deploy the Managed Metadata service app to the local SharePoint farm.
+    This example shows how to configure a default Managed Metadata service app for the default
+    proxy group.
 #>
 
 Configuration Example

--- a/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/1-SetManagedMetadataDefault.ps1
@@ -15,7 +15,7 @@ Configuration Example
     node localhost {
         SPManagedMetaDataServiceAppDefault ManagedMetadataServiceAppDefault
         {
-            IsSingleInstance               = "Yes"
+            ServiceAppProxyGroup           = "Default"
             DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
             DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
             PsDscRunAsCredential           = $SetupAccount

--- a/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/2-ConfigureCustomProxyGroup.ps1
+++ b/Modules/SharePointDsc/Examples/Resources/SPManagedMetaDataServiceAppDefault/2-ConfigureCustomProxyGroup.ps1
@@ -1,0 +1,33 @@
+<#
+.EXAMPLE
+    This example shows how to configure a custom proxy group and specify its default Managed
+    Metadata service app.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $SetupAccount
+    )
+    Import-DscResource -ModuleName SharePointDsc
+
+    node localhost {
+        SPServiceAppProxyGroup ProxyGroup1
+        {
+            Name                 = "Proxy Group 1"
+            Ensure               = "Present"
+            ServiceAppProxies    = @("User Profile Service Application","MMS Service Application","State Service Application")
+            PsDscRunAsCredential = $SetupAccount
+        }
+
+        SPManagedMetaDataServiceAppDefault ManagedMetadataServiceAppDefault
+        {
+            ServiceAppProxyGroup           = "Proxy Group 1"
+            DefaultSiteCollectionProxyName = "MMS Service Application Proxy"
+            DefaultKeywordProxyName        = "MMS Service Application Proxy"
+            PsDscRunAsCredential           = $SetupAccount
+        }
+    }
+}

--- a/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
+++ b/Tests/Unit/SharePointDsc/SharePointDsc.SPManagedMetadataServiceAppDefault.Tests.ps1
@@ -66,56 +66,85 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
         } `
             -PassThru -Force
 
-        Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
-            return @(
-                $managedMetadataServiceApplicationProxy,
-                $managedMetadataServiceApplicationProxyDefault
-            )
+        Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
+            return @{
+                Proxies = @(
+                    $managedMetadataServiceApplicationProxy,
+                    $managedMetadataServiceApplicationProxyDefault
+                )
+            }
         }
 
-        Context -Name "When no service application proxy or managed metadata service application proxy exist in the farm" -Fixture {
+        Context -Name "Specified proxy group does not exist" -Fixture {
             $testParams = @{
-                IsSingleInstance               = "Yes"
+                ServiceAppProxyGroup           = "DoesNotExist"
                 DefaultSiteCollectionProxyName = "DefaultSiteCollectionProxyName"
                 DefaultKeywordProxyName        = "DefaultKeywordProxyName"
             }
 
-            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
+            Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
                 return $null
             }
 
-            It "Should throw an error, when no Service Application Proxy is available" {
-                { Get-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxy available in the farm"
+            It "Should throw an error in the Get Method, when the Service Application Proxy Group does not exist" {
+                { Get-TargetResource @testParams } | Should Throw "Specified ServiceAppProxyGroup $($testParams.ServiceAppProxyGroup) does not exist."
             }
 
-            $mockProxy = @{
-                TypeName = "Mock Proxy"
-                Name     = "Mock Proxy"
+            It "Should throw an error in the Set Method, when the Service Application Proxy Group does not exist" {
+                { Set-TargetResource @testParams } | Should Throw "Specified ServiceAppProxyGroup $($testParams.ServiceAppProxyGroup) does not exist."
+            }
+        }
 
-            } `
-            | Add-Member -MemberType ScriptMethod `
-                -Name GetType `
-                -Value { `
-                    return (@{
-                        FullName = "Mock Proxy"
-                    }) `
-            } `
-                -PassThru -Force
-
-            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
-                return @(
-                    $mockProxy
-                )
+        Context -Name "When no service application proxy or managed metadata service application proxy exist in the farm" -Fixture {
+            $testParams = @{
+                ServiceAppProxyGroup           = "ProxyGroup"
+                DefaultSiteCollectionProxyName = "DefaultSiteCollectionProxyName"
+                DefaultKeywordProxyName        = "DefaultKeywordProxyName"
             }
 
-            It "Should throw an error, when no Service Application Proxy is available" {
-                { Get-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxy available in the farm"
+            Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
+                return @{
+                    Proxies = $null
+                }
+            }
+
+            It "Should throw an error in the Get Method, when no Service Application Proxy is available" {
+                { Get-TargetResource @testParams } | Should Throw "There are no Service Application Proxies available in the proxy group"
+            }
+
+            It "Should throw an error in the Set Method, when no Service Application Proxy is available" {
+                { Set-TargetResource @testParams } | Should Throw "There are no Service Application Proxies available in the proxy group"
+            }
+
+            Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
+                return @{
+                    Proxies = @{
+                        TypeName = "Mock Proxy"
+                        Name     = "Mock Proxy"
+                    } `
+                    | Add-Member -MemberType ScriptMethod `
+                        -Name GetType `
+                        -Value { `
+                            return (@{
+                                FullName = "Mock Proxy"
+                            }) `
+                    } `
+                        -PassThru -Force
+                }
+            }
+
+            It "Should throw an error in the Get method, when no MMS Service Application Proxy is available" {
+                { Get-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxies available in the proxy group"
+            }
+
+            It "Should throw an error in the Set method, when no MMS Service Application Proxy is available" {
+                { Set-TargetResource @testParams } | Should Throw "There are no Managed Metadata Service Application Proxies available in the proxy group"
             }
         }
 
         Context -Name "When one managed metadata service application proxy exists and should be the default" -Fixture {
             $testParams = @{
-                IsSingleInstance               = "Yes"
+                ServiceAppProxyGroup           = "Default"
                 DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
                 DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
             }
@@ -143,10 +172,12 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             } `
                 -PassThru -Force
 
-            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
-                return @(
-                    $managedMetadataServiceApplicationProxyMock
-                )
+            Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
+                return @{
+                    Proxies = @(
+                        $managedMetadataServiceApplicationProxyMock
+                    )
+                }
             }
 
             It "Should return false when the test method is called" {
@@ -172,7 +203,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
         Context -Name "When several managed metadata service application proxy exists and another should be the default" -Fixture {
             $testParams = @{
-                IsSingleInstance               = "Yes"
+                ServiceAppProxyGroup           = "ProxyGroup"
                 DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
                 DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
             }
@@ -206,7 +237,7 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
 
         Context -Name "When several managed metadata service application proxy exists, both are default" -Fixture {
             $testParams = @{
-                IsSingleInstance               = "Yes"
+                ServiceAppProxyGroup           = "ProxyGroup"
                 DefaultSiteCollectionProxyName = "Managed Metadata Service Application Proxy"
                 DefaultKeywordProxyName        = "Managed Metadata Service Application Proxy"
             }
@@ -234,11 +265,13 @@ Describe -Name $Global:SPDscHelper.DescribeHeader -Fixture {
             } `
                 -PassThru -Force
 
-            Mock -CommandName Get-SPServiceApplicationProxy -MockWith {
-                return @(
-                    $managedMetadataServiceApplicationProxyDefault,
-                    $managedMetadataServiceApplicationProxyDefault
-                )
+            Mock -CommandName Get-SPServiceApplicationProxyGroup -MockWith {
+                return @{
+                    Proxies = @(
+                        $managedMetadataServiceApplicationProxyDefault,
+                        $managedMetadataServiceApplicationProxyDefault
+                    )
+                }
             }
 
             It "Should return false when the test method is called" {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR updates the SPManagedMetadataServiceAppDefault resource to allow configuration of a default MMS Service App per Proxy Group. In the old version, it only allowed one default per farm, which is not correct.

This is however a breaking change, so will be merged into the v4.0 branch

#### This Pull Request (PR) fixes the following issues
- Fixes #1136 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/sharepointdsc/1137)
<!-- Reviewable:end -->
